### PR TITLE
fix: handle string roles in conversation history restoration

### DIFF
--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(bundle install)
 description: Bump version, update changelog and commit changes
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-07-08
+
+### Fixed
+- Fixed string role handling in conversation history restoration
+  - `msg[:role]` is now converted to symbol before checking inclusion in restore_conversation_history
+  - Prevents string roles like "user" from being skipped during history restoration
+
 ## [0.2.0] - 2025-07-08
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-agents (0.2.0)
+    ai-agents (0.2.1)
       ruby_llm (~> 1.3)
 
 GEM

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -199,7 +199,7 @@ module Agents
 
       history.each do |msg|
         # Only restore user and assistant messages with content
-        next unless %i[user assistant].include?(msg[:role])
+        next unless %i[user assistant].include?(msg[:role].to_sym)
         next unless msg[:content] && !msg[:content].strip.empty?
 
         chat.add_message(

--- a/lib/agents/version.rb
+++ b/lib/agents/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Agents
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/agents/runner_spec.rb
+++ b/spec/agents/runner_spec.rb
@@ -124,6 +124,25 @@ RSpec.describe Agents::Runner do
         expect(result.output).to eq("Yes, that's correct! Is there anything else?")
         expect(result.messages.length).to eq(4) # 2 from history + 2 new
       end
+
+      context "with string roles in history" do
+        let(:context_with_string_roles) do
+          {
+            conversation_history: [
+              { role: "user", content: "What's 2+2?" },
+              { role: "assistant", content: "2+2 equals 4." }
+            ]
+          }
+        end
+
+        it "handles string roles correctly" do
+          result = runner.run(agent, "Thanks for confirming", context: context_with_string_roles)
+
+          expect(result.success?).to be true
+          expect(result.output).to eq("Yes, that's correct! Is there anything else?")
+          expect(result.messages.length).to eq(4) # 2 from history + 2 new
+        end
+      end
     end
 
     context "when using current_agent from context" do


### PR DESCRIPTION
- Convert msg[:role] to symbol before checking inclusion in restore_conversation_history
- Add test case for string role handling to ensure compatibility
- Fixes issue where string roles like "user" would be skipped during history restoration