### PR TITLE
feat: replace based chat configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,20 +10,18 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-RSpec/MultipleExpectations:
-  Max: 10
-
-RSpec/ExampleLength:
-  Max: 20
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 15
-
-RSpec/SpecFilePathFormat:
-  Enabled: false
-
 Metrics/MethodLength:
   Max: 20
+Metrics/ClassLength:
+  Enabled: false
 
 RSpec/MultipleDescribes:
+  Enabled: false
+RSpec/MultipleExpectations:
+  Max: 10
+RSpec/ExampleLength:
+  Max: 20
+RSpec/MultipleMemoizedHelpers:
+  Max: 15
+RSpec/SpecFilePathFormat:
   Enabled: false

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -55,6 +55,7 @@ module Agents
     DEFAULT_MAX_TURNS = 10
 
     class MaxTurnsExceeded < StandardError; end
+    class AgentNotFoundError < StandardError; end
 
     # Create a thread-safe agent runner for multi-agent conversations.
     # The first agent becomes the default entry point for new conversations.
@@ -120,7 +121,7 @@ module Agents
           # This prevents handoffs to agents that weren't explicitly provided
           unless registry[next_agent.name]
             save_conversation_state(chat, context_wrapper, current_agent)
-            error = StandardError.new("Handoff failed: Agent '#{next_agent.name}' not found in registry")
+            error = AgentNotFoundError.new("Handoff failed: Agent '#{next_agent.name}' not found in registry")
             return RunResult.new(
               output: nil,
               messages: MessageExtractor.extract_messages(chat, current_agent),

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -238,16 +238,7 @@ module Agents
           content: content
         )
         chat.add_message(message)
-      rescue StandardError => e
-        # Continue with partial history on error
-        # TODO: Remove this, and let the error propagate up the call stack
-        puts "[Agents] Failed to restore message: #{e.message}\n#{e.backtrace.join("\n")}"
       end
-    rescue StandardError => e
-      # If history restoration completely fails, continue with empty history
-      # TODO: Remove this, and let the error propagate up the call stack
-      puts "[Agents] Failed to restore conversation history: #{e.message}"
-      context_wrapper.context[:conversation_history] = []
     end
 
     # Saves current conversation state from RubyLLM chat back to context for persistence.

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -119,14 +119,14 @@ module Agents
           # Validate that the target agent is in our registry
           # This prevents handoffs to agents that weren't explicitly provided
           unless registry[next_agent.name]
-            puts "[Agents] Warning: Handoff to unregistered agent '#{next_agent.name}', continuing with current agent"
-            # Return the halt content as the final response
             save_conversation_state(chat, context_wrapper, current_agent)
+            error = StandardError.new("Handoff failed: Agent '#{next_agent.name}' not found in registry")
             return RunResult.new(
-              output: response.content,
+              output: nil,
               messages: MessageExtractor.extract_messages(chat, current_agent),
               usage: context_wrapper.usage,
-              context: context_wrapper.context
+              context: context_wrapper.context,
+              error: error
             )
           end
 

--- a/spec/agents/runner_spec.rb
+++ b/spec/agents/runner_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Agents::Runner do
         result = runner.run(agent_with_handoffs, "I need specialist help", registry: registry)
 
         expect(result.failed?).to be true
-        expect(result.error).to be_a(StandardError)
+        expect(result.error).to be_a(Agents::Runner::AgentNotFoundError)
         expect(result.error.message).to eq("Handoff failed: Agent 'HandoffAgent' not found in registry")
         expect(result.output).to be_nil
         expect(result.context[:current_agent]).to eq("TriageAgent")

--- a/spec/agents/runner_spec.rb
+++ b/spec/agents/runner_spec.rb
@@ -196,6 +196,50 @@ RSpec.describe Agents::Runner do
         expect(result.output).to eq("Hello, I'm the specialist. How can I help?")
         expect(result.context[:current_agent]).to eq("HandoffAgent")
       end
+
+      it "returns error when handoff to unregistered agent is attempted" do
+        # Only register the triage agent, not the handoff target
+        registry = { "TriageAgent" => agent_with_handoffs }
+
+        # Mock only the first tool call that triggers handoff
+        stub_request(:post, "https://api.openai.com/v1/chat/completions")
+          .to_return(
+            status: 200,
+            body: {
+              id: "chatcmpl-handoff",
+              object: "chat.completion",
+              created: 1_677_652_288,
+              model: "gpt-4o",
+              choices: [{
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: nil,
+                  tool_calls: [{
+                    id: "call_handoff",
+                    type: "function",
+                    function: {
+                      name: "handoff_to_handoffagent",
+                      arguments: "{}"
+                    }
+                  }]
+                },
+                finish_reason: "tool_calls"
+              }],
+              usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 }
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        result = runner.run(agent_with_handoffs, "I need specialist help", registry: registry)
+
+        expect(result.failed?).to be true
+        expect(result.error).to be_a(StandardError)
+        expect(result.error.message).to eq("Handoff failed: Agent 'HandoffAgent' not found in registry")
+        expect(result.output).to be_nil
+        expect(result.context[:current_agent]).to eq("TriageAgent")
+        expect(result.context[:pending_handoff]).to be_nil # Should clear pending handoff
+      end
     end
 
     context "when max_turns is exceeded" do
@@ -204,8 +248,9 @@ RSpec.describe Agents::Runner do
         mock_chat = instance_double(RubyLLM::Chat)
         mock_response = instance_double(RubyLLM::Message, tool_call?: true)
 
+        allow(RubyLLM::Chat).to receive(:new).and_return(mock_chat)
         allow(runner).to receive_messages(
-          create_chat: mock_chat,
+          configure_chat_for_agent: mock_chat,
           restore_conversation_history: nil,
           save_conversation_state: nil
         )
@@ -224,7 +269,7 @@ RSpec.describe Agents::Runner do
     context "when standard error occurs" do
       it "handles errors gracefully and returns error result" do
         # Mock chat creation to raise an error
-        allow(runner).to receive(:create_chat).and_raise(StandardError, "Test error")
+        allow(RubyLLM::Chat).to receive(:new).and_raise(StandardError, "Test error")
 
         result = runner.run(agent, "Error test")
 
@@ -272,8 +317,9 @@ RSpec.describe Agents::Runner do
         mock_halt = instance_double(RubyLLM::Tool::Halt, content: "Processing complete", is_a?: true)
 
         allow(mock_halt).to receive(:is_a?).with(RubyLLM::Tool::Halt).and_return(true)
+        allow(RubyLLM::Chat).to receive(:new).and_return(mock_chat)
         allow(runner).to receive_messages(
-          create_chat: mock_chat,
+          configure_chat_for_agent: mock_chat,
           restore_conversation_history: nil,
           save_conversation_state: nil
         )

--- a/spec/agents/tool_context_spec.rb
+++ b/spec/agents/tool_context_spec.rb
@@ -48,4 +48,51 @@ RSpec.describe Agents::ToolContext do
       expect(tool_context.retry_count).to eq(2)
     end
   end
+
+  describe "#state" do
+    context "when state exists in context" do
+      let(:existing_state) { { customer_id: 456, customer_name: "John" } }
+      let(:context_hash) { { user_id: 123, session: "test", state: existing_state } }
+
+      it "returns the existing state hash" do
+        result = tool_context.state
+        expect(result).to eq(existing_state)
+      end
+
+      it "allows modifications to the state" do
+        tool_context.state[:new_key] = "new_value"
+        expect(tool_context.state[:new_key]).to eq("new_value")
+      end
+    end
+
+    context "when state does not exist in context" do
+      let(:context_hash) { { user_id: 123, session: "test" } }
+
+      it "initializes state as empty hash" do
+        result = tool_context.state
+        expect(result).to eq({})
+      end
+
+      it "persists the initialized state in context" do
+        tool_context.state
+        expect(context_hash[:state]).to eq({})
+      end
+
+      it "allows adding to the initialized state" do
+        tool_context.state[:customer_id] = 789
+        expect(tool_context.state[:customer_id]).to eq(789)
+        expect(context_hash[:state][:customer_id]).to eq(789)
+      end
+    end
+
+    context "when state is nil in context" do
+      let(:context_hash) { { user_id: 123, session: "test", state: nil } }
+
+      it "replaces nil with empty hash" do
+        result = tool_context.state
+        expect(result).to eq({})
+        expect(context_hash[:state]).to eq({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request improves how we handle agent handoffs and chat configuration, making the system more robust and easier to debug. The main changes focus on leveraging RubyLLM's newer chat configuration features while strengthening error handling throughout the runner.

## What Changed

**Improved Chat Configuration**
We now reuse chat instances during handoffs instead of creating new ones. This preserves conversation history when agents hand off to each other, and it's more efficient too. We use RubyLLM's `replace` option to swap out agent-specific settings while keeping the conversation intact.

**Better Error Handling**
When an agent tries to hand off to an unregistered agent, we now return a proper error instead of just logging a warning. This makes configuration issues much easier to spot and debug.

**Cleaner Error Propagation**
Removed some error swallowing around conversation restoration so real problems don't get hidden.