### PR TITLE
upd: Bump ruby_llm dependency and remove PATCH semantic version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ai-agents (0.9.1)
-      ruby_llm (~> 1.9.1)
+      ruby_llm (~> 1.14)
 
 GEM
   remote: https://rubygems.org/
@@ -34,6 +34,9 @@ GEM
       bigdecimal
       rake (>= 13)
     google-protobuf (4.33.4-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
     googleapis-common-protos-types (1.22.0)
@@ -125,15 +128,15 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
-    ruby_llm (1.9.1)
+    ruby_llm (1.14.0)
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)
       faraday-multipart (>= 1)
       faraday-net_http (>= 1)
       faraday-retry (>= 1)
-      marcel (~> 1.0)
-      ruby_llm-schema (~> 0.2.1)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
       zeitwerk (~> 2)
     ruby_llm-schema (0.2.1)
     simplecov (0.22.0)
@@ -157,6 +160,7 @@ GEM
 PLATFORMS
   arm64-darwin-24
   ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   ai-agents!

--- a/ai-agents.gemspec
+++ b/ai-agents.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Core dependencies
-  spec.add_dependency "ruby_llm", "~> 1.9.1"
+  spec.add_dependency "ruby_llm", "~> 1.14"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Removing the PATCH semantic version constraint will allow users of ai-agents to use any non-breaking new version of ruby_llm, even if ruby_llm is not released for those new versions. It is safe as long as ruby_llm respects semantic versioning, which apparently is assumed given that the semantic operator ~> is already used for version constraint.