### PR TITLE
chore: loosen ruby_llm dependency to >= 1.9.1

### DIFF
--- a/ai-agents.gemspec
+++ b/ai-agents.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Core dependencies
-  spec.add_dependency "ruby_llm", "~> 1.9.1"
+  spec.add_dependency "ruby_llm", ">= 1.9.1"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/agents/version.rb
+++ b/lib/agents/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Agents
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end


### PR DESCRIPTION
Allow consumers to upgrade ruby_llm beyond 1.9.x for native OpenRouter support.