### PR TITLE
chore: release version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Bump `ruby_llm` dependency**: now `~> 1.14` (was `~> 1.9.1`). Trusts upstream semantic versioning by dropping the PATCH-level pin so minor-version fixes are picked up automatically (#61)
+- Various internal refactors to `TracingCallbacks`, `Runner`, and helper modules
 
 
 ## [0.9.1] - 2026-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.10.0] - 2026-04-20
+
 ### Added
-- Support for provider specific params
+- Support for provider-specific params via `with_params` (#44)
+
+### Changed
+- **Bump `ruby_llm` dependency**: now `~> 1.14` (was `~> 1.9.1`). Trusts upstream semantic versioning by dropping the PATCH-level pin so minor-version fixes are picked up automatically (#61)
+
+### Internal
+- Extract `NameNormalizer` for agent-to-tool-name conversion (#53)
+- Remove duplicate `serialize_content` in `TracingCallbacks` (#52)
+- Remove duplicate Headers and Params helper wrappers (#51)
+- Expose agents via `attr_reader` on `AgentRunner` (#54)
+- Extract `finalize_run` helper to deduplicate Runner exit paths (#56)
+- Eliminate redundant work and inconsistency in `TracingCallbacks` (#57)
 
 
 ## [0.9.1] - 2026-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Bump `ruby_llm` dependency**: now `~> 1.14` (was `~> 1.9.1`). Trusts upstream semantic versioning by dropping the PATCH-level pin so minor-version fixes are picked up automatically (#61)
 
-### Internal
-- Extract `NameNormalizer` for agent-to-tool-name conversion (#53)
-- Remove duplicate `serialize_content` in `TracingCallbacks` (#52)
-- Remove duplicate Headers and Params helper wrappers (#51)
-- Expose agents via `attr_reader` on `AgentRunner` (#54)
-- Extract `finalize_run` helper to deduplicate Runner exit paths (#56)
-- Eliminate redundant work and inconsistency in `TracingCallbacks` (#57)
-
 
 ## [0.9.1] - 2026-02-24
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-agents (0.9.1)
+    ai-agents (0.10.0)
       ruby_llm (~> 1.14)
 
 GEM

--- a/lib/agents/version.rb
+++ b/lib/agents/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Agents
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION
Bumps MINOR for the ruby_llm dependency major upgrade (~> 1.9.1 → ~> 1.14) merged in #61, along with provider-specific params support (#44)