### PR TITLE
feat: add RubyLLM provider passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-27
+
 ### Added
 - Support RubyLLM provider overrides and custom model/deployment IDs on agents, including Azure configuration passthrough (#66)
 
 ### Fixed
-- Preserve per-message assistant agent attribution when restoring and snapshotting multi-agent conversation history, preventing earlier assistant messages from being re-labeled as the final active agent after handoffs (#67)
+- Preserve per-message assistant agent attribution when restoring and snapshotting multi-agent conversation history, preventing earlier assistant messages from being re-labeled as the final active agent after handoffs (#68)
 
 ## [0.10.0] - 2026-04-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-agents (0.10.0)
+    ai-agents (0.11.0)
       ruby_llm (~> 1.14)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -193,21 +193,39 @@ ruby examples/isp-support/interactive.rb
 Agents.configure do |config|
   # Provider API keys
   config.openai_api_key = ENV['OPENAI_API_KEY']
+  config.azure_api_base = ENV['AZURE_API_BASE']
+  config.azure_api_key = ENV['AZURE_API_KEY']
   config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
   config.gemini_api_key = ENV['GEMINI_API_KEY']
 
   # Defaults
-  config.default_provider = :openai
   config.default_model = 'gpt-4o'
 
   # Performance
   config.request_timeout = 120
-  config.max_turns = 10
 
   # Debugging
   config.debug = true
 end
 ```
+
+### Azure and Custom Deployments
+
+```ruby
+Agents.configure do |config|
+  config.azure_api_base = ENV["AZURE_API_BASE"]
+  config.azure_api_key = ENV["AZURE_API_KEY"]
+end
+
+agent = Agents::Agent.new(
+  name: "Support",
+  model: "my-azure-deployment",
+  provider: :azure,
+  assume_model_exists: true
+)
+```
+
+`provider` is optional for known, unambiguous registry models. Set it for custom deployment names and for model IDs that can exist under multiple providers, such as Azure and OpenAI deployments.
 
 ## 🔍 Observability
 

--- a/docs/guides/rails-integration.md
+++ b/docs/guides/rails-integration.md
@@ -24,10 +24,23 @@ Configure your LLM providers in an initializer:
 # config/initializers/ai_agents.rb
 Agents.configure do |config|
   config.openai_api_key = Rails.application.credentials.openai_api_key
+  config.azure_api_base = Rails.application.credentials.azure_api_base
+  config.azure_api_key = Rails.application.credentials.azure_api_key
   config.anthropic_api_key = Rails.application.credentials.anthropic_api_key
   config.default_model = 'gpt-4o-mini'
   config.debug = Rails.env.development?
 end
+```
+
+For Azure custom deployment names, pass the provider at the agent level:
+
+```ruby
+support = Agents::Agent.new(
+  name: "Support",
+  model: "my-azure-deployment",
+  provider: :azure,
+  assume_model_exists: true
+)
 ```
 
 ## ActiveRecord Integration

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,8 @@ require 'agents'
 # Configure your API keys
 Agents.configure do |config|
   config.openai_api_key = ENV['OPENAI_API_KEY']
+  # config.azure_api_base = ENV['AZURE_API_BASE']
+  # config.azure_api_key = ENV['AZURE_API_KEY']
   # config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
   # config.gemini_api_key = ENV['GEMINI_API_KEY']
   config.default_model = 'gpt-4o-mini'
@@ -86,6 +88,24 @@ result = runner.run("I need help with a technical issue")
 
 puts result.output
 ```
+
+### Azure and Custom Deployments
+
+```ruby
+Agents.configure do |config|
+  config.azure_api_base = ENV["AZURE_API_BASE"]
+  config.azure_api_key = ENV["AZURE_API_KEY"]
+end
+
+agent = Agents::Agent.new(
+  name: "Support",
+  model: "my-azure-deployment",
+  provider: :azure,
+  assume_model_exists: true
+)
+```
+
+`provider` is optional for known, unambiguous registry models. Set it for custom deployment names and duplicate model IDs, such as Azure and OpenAI deployments.
 
 ## Next Steps
 

--- a/lib/agents.rb
+++ b/lib/agents.rb
@@ -56,6 +56,9 @@ module Agents
 
       # Other providers
       apply_if_present(config, :anthropic_api_key)
+      apply_if_present(config, :azure_api_base)
+      apply_if_present(config, :azure_api_key)
+      apply_if_present(config, :azure_ai_auth_token)
       apply_if_present(config, :gemini_api_key)
       apply_if_present(config, :deepseek_api_key)
       apply_if_present(config, :openrouter_api_key)
@@ -83,8 +86,9 @@ module Agents
   class Configuration
     # Provider API keys and configuration
     attr_accessor :openai_api_key, :openai_api_base, :openai_organization_id, :openai_project_id
-    attr_accessor :anthropic_api_key, :gemini_api_key, :deepseek_api_key, :openrouter_api_key, :ollama_api_base,
-                  :bedrock_api_key, :bedrock_secret_key, :bedrock_region, :bedrock_session_token
+    attr_accessor :anthropic_api_key, :azure_api_base, :azure_api_key, :azure_ai_auth_token, :gemini_api_key,
+                  :deepseek_api_key, :openrouter_api_key, :ollama_api_base, :bedrock_api_key, :bedrock_secret_key,
+                  :bedrock_region, :bedrock_session_token
 
     # General configuration
     attr_accessor :request_timeout, :default_model, :debug
@@ -100,7 +104,7 @@ module Agents
     def configured?
       @openai_api_key || @anthropic_api_key || @gemini_api_key ||
         @deepseek_api_key || @openrouter_api_key || @ollama_api_base ||
-        @bedrock_api_key
+        @bedrock_api_key || (@azure_api_base && (@azure_api_key || @azure_ai_auth_token))
     end
   end
 end

--- a/lib/agents/agent.rb
+++ b/lib/agents/agent.rb
@@ -50,24 +50,29 @@ require_relative "helpers/hash_normalizer"
 #   )
 module Agents
   class Agent
-    attr_reader :name, :instructions, :model, :tools, :handoff_agents, :temperature, :response_schema, :headers, :params
+    attr_reader :name, :instructions, :model, :provider, :assume_model_exists, :tools, :handoff_agents, :temperature,
+                :response_schema, :headers, :params
 
     # Initialize a new Agent instance
     #
     # @param name [String] The name of the agent
     # @param instructions [String, Proc, nil] Static string or dynamic Proc that returns instructions
     # @param model [String] The LLM model to use (default: "gpt-4.1-mini")
+    # @param provider [Symbol, String, nil] Optional RubyLLM provider override
+    # @param assume_model_exists [Boolean] Whether RubyLLM should skip registry validation for custom model IDs
     # @param tools [Array<Agents::Tool>] Array of tool instances the agent can use
     # @param handoff_agents [Array<Agents::Agent>] Array of agents this agent can hand off to
     # @param temperature [Float] Controls randomness in responses (0.0 = deterministic, 1.0 = very random, default: 0.7)
     # @param response_schema [Hash, nil] JSON schema for structured output responses
     # @param headers [Hash, nil] Default HTTP headers applied to LLM requests
     # @param params [Hash, nil] Default provider-specific parameters applied to LLM requests (e.g., service_tier)
-    def initialize(name:, instructions: nil, model: "gpt-4.1-mini", tools: [], handoff_agents: [], temperature: 0.7,
-                   response_schema: nil, headers: nil, params: nil)
+    def initialize(name:, instructions: nil, model: "gpt-4.1-mini", provider: nil, assume_model_exists: false,
+                   tools: [], handoff_agents: [], temperature: 0.7, response_schema: nil, headers: nil, params: nil)
       @name = name
       @instructions = instructions
       @model = model
+      @provider = provider&.to_sym
+      @assume_model_exists = assume_model_exists
       @tools = tools.dup
       @handoff_agents = []
       @temperature = temperature
@@ -155,6 +160,8 @@ module Agents
     # @option changes [String] :name New agent name
     # @option changes [String, Proc] :instructions New instructions
     # @option changes [String] :model New model identifier
+    # @option changes [Symbol, String, nil] :provider New provider override
+    # @option changes [Boolean] :assume_model_exists Whether to skip model registry validation
     # @option changes [Array<Agents::Tool>] :tools New tools array (replaces all tools)
     # @option changes [Array<Agents::Agent>] :handoff_agents New handoff agents
     # @option changes [Float] :temperature Temperature for LLM responses (0.0-1.0)
@@ -165,6 +172,8 @@ module Agents
         name: changes.fetch(:name, @name),
         instructions: changes.fetch(:instructions, @instructions),
         model: changes.fetch(:model, @model),
+        provider: changes.fetch(:provider, @provider),
+        assume_model_exists: changes.fetch(:assume_model_exists, @assume_model_exists),
         tools: changes.fetch(:tools, @tools.dup),
         handoff_agents: changes.fetch(:handoff_agents, @handoff_agents),
         temperature: changes.fetch(:temperature, @temperature),

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -103,7 +103,11 @@ module Agents
       agent_params = Helpers::HashNormalizer.normalize(current_agent.params, label: "params")
 
       # Create chat and restore conversation history
-      chat = RubyLLM::Chat.new(model: current_agent.model)
+      chat = RubyLLM::Chat.new(
+        model: current_agent.model,
+        provider: current_agent.provider,
+        assume_model_exists: current_agent.assume_model_exists
+      )
       current_headers = Helpers::HashNormalizer.merge(agent_headers, runtime_headers)
       current_params = Helpers::HashNormalizer.merge(agent_params, runtime_params)
       apply_headers(chat, current_headers)
@@ -393,7 +397,13 @@ module Agents
       all_tools = build_agent_tools(agent, context_wrapper)
 
       # Switch model if different (important for handoffs between agents using different models)
-      chat.with_model(agent.model) if replace
+      if replace
+        chat.with_model(
+          agent.model,
+          provider: agent.provider,
+          assume_exists: agent.assume_model_exists
+        )
+      end
 
       # Configure chat with instructions, temperature, tools, and schema
       chat.with_instructions(system_prompt, replace: replace) if system_prompt

--- a/lib/agents/version.rb
+++ b/lib/agents/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Agents
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/spec/agents/agent_spec.rb
+++ b/spec/agents/agent_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Agents::Agent do
       expect(agent.name).to eq("Test Agent")
       expect(agent.instructions).to be_nil
       expect(agent.model).to eq("gpt-4.1-mini")
+      expect(agent.provider).to be_nil
+      expect(agent.assume_model_exists).to be false
       expect(agent.tools).to eq([])
       expect(agent.handoff_agents).to eq([])
       expect(agent.temperature).to eq(0.7)
@@ -33,6 +35,8 @@ RSpec.describe Agents::Agent do
         name: "Test Agent",
         instructions: instructions,
         model: "gpt-4o",
+        provider: :azure,
+        assume_model_exists: true,
         tools: tools,
         handoff_agents: handoff_agents,
         temperature: 0.9,
@@ -42,6 +46,8 @@ RSpec.describe Agents::Agent do
       expect(agent.name).to eq("Test Agent")
       expect(agent.instructions).to eq(instructions)
       expect(agent.model).to eq("gpt-4o")
+      expect(agent.provider).to eq(:azure)
+      expect(agent.assume_model_exists).to be true
       expect(agent.tools).to eq(tools)
       expect(agent.handoff_agents).to include(other_agent)
       expect(agent.temperature).to eq(0.9)
@@ -74,6 +80,12 @@ RSpec.describe Agents::Agent do
       agent = described_class.new(name: "Test", temperature: 0.2)
 
       expect(agent.temperature).to eq(0.2)
+    end
+
+    it "normalizes string provider to symbol" do
+      agent = described_class.new(name: "Test", provider: "azure")
+
+      expect(agent.provider).to eq(:azure)
     end
 
     it "creates agent with response_schema" do
@@ -194,6 +206,8 @@ RSpec.describe Agents::Agent do
         name: "Original",
         instructions: "Original instructions",
         model: "gpt-4",
+        provider: :azure,
+        assume_model_exists: true,
         tools: [test_tool],
         handoff_agents: [other_agent],
         temperature: 0.7,
@@ -208,6 +222,8 @@ RSpec.describe Agents::Agent do
       expect(cloned.name).to eq("Original")
       expect(cloned.instructions).to eq("Original instructions")
       expect(cloned.model).to eq("gpt-4")
+      expect(cloned.provider).to eq(:azure)
+      expect(cloned.assume_model_exists).to be true
       expect(cloned.tools).to eq([test_tool])
       expect(cloned.handoff_agents).to eq([other_agent])
       expect(cloned.headers).to eq("X-Test": "value")
@@ -222,6 +238,8 @@ RSpec.describe Agents::Agent do
 
       expect(cloned.name).to eq("Cloned")
       expect(cloned.model).to eq("gpt-3.5-turbo")
+      expect(cloned.provider).to eq(:azure)
+      expect(cloned.assume_model_exists).to be true
       expect(cloned.instructions).to eq("Original instructions")
       expect(cloned.tools).to eq([test_tool])
       expect(cloned.temperature).to eq(0.7)
@@ -282,6 +300,15 @@ RSpec.describe Agents::Agent do
 
       expect(cloned.params).to eq(service_tier: "flex")
       expect(agent_with_params.params).to eq(service_tier: "default")
+    end
+
+    it "allows overriding provider and assume_model_exists when cloning" do
+      cloned = original_agent.clone(provider: :openai, assume_model_exists: false)
+
+      expect(cloned.provider).to eq(:openai)
+      expect(cloned.assume_model_exists).to be false
+      expect(original_agent.provider).to eq(:azure)
+      expect(original_agent.assume_model_exists).to be true
     end
   end
 

--- a/spec/agents/runner_spec.rb
+++ b/spec/agents/runner_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Agents::Runner do
     instance_double(Agents::Agent,
                     name: "TestAgent",
                     model: "gpt-4o",
+                    provider: nil,
+                    assume_model_exists: false,
                     tools: [],
                     handoff_agents: [],
                     temperature: 0.7,
@@ -32,6 +34,8 @@ RSpec.describe Agents::Runner do
     instance_double(Agents::Agent,
                     name: "HandoffAgent",
                     model: "gpt-4o",
+                    provider: nil,
+                    assume_model_exists: false,
                     tools: [],
                     handoff_agents: [],
                     temperature: 0.7,
@@ -89,6 +93,40 @@ RSpec.describe Agents::Runner do
         expect(result.context).to include(:conversation_history)
         expect(result.context).to include(turn_count: 1)
         expect(result.context).to include(:last_updated)
+      end
+
+      it "creates RubyLLM chat with provider and assume_model_exists from the agent" do
+        azure_agent = instance_double(
+          Agents::Agent,
+          name: "AzureAgent",
+          model: "deployment-name",
+          provider: :azure,
+          assume_model_exists: true,
+          tools: [],
+          handoff_agents: [],
+          temperature: 0.7,
+          response_schema: nil,
+          get_system_prompt: "You are a helpful assistant",
+          headers: {},
+          params: {}
+        )
+        mock_chat = instance_double(RubyLLM::Chat)
+        mock_response = instance_double(RubyLLM::Message, tool_call?: false, content: "Hello from Azure",
+                                                          input_tokens: 10, output_tokens: 5)
+
+        expect(RubyLLM::Chat).to receive(:new).with(
+          model: "deployment-name",
+          provider: :azure,
+          assume_model_exists: true
+        ).and_return(mock_chat)
+        allow(mock_chat).to receive(:add_message)
+        allow(Agents::Helpers::MessageExtractor).to receive(:extract_messages).and_return([])
+        allow(mock_chat).to receive_messages(with_instructions: mock_chat, with_temperature: mock_chat,
+                                             with_tools: mock_chat, with_schema: mock_chat, ask: mock_response)
+
+        result = runner.run(azure_agent, "Hello")
+
+        expect(result.output).to eq("Hello from Azure")
       end
     end
 
@@ -848,6 +886,8 @@ RSpec.describe Agents::Runner do
         instance_double(Agents::Agent,
                         name: "TriageAgent",
                         model: "gpt-4o",
+                        provider: nil,
+                        assume_model_exists: false,
                         tools: [],
                         handoff_agents: [handoff_agent],
                         temperature: 0.7,
@@ -873,6 +913,29 @@ RSpec.describe Agents::Runner do
         expect(result.success?).to be true
         expect(result.output).to eq("Hello, I'm the specialist. How can I help?")
         expect(result.context[:current_agent]).to eq("HandoffAgent")
+      end
+
+      it "switches handoff chat to the target agent model and provider" do
+        allow(handoff_agent).to receive_messages(
+          model: "deployment-name",
+          provider: :azure,
+          assume_model_exists: true
+        )
+        mock_chat = instance_double(RubyLLM::Chat)
+        context_wrapper = Agents::RunContext.new({})
+
+        allow(mock_chat).to receive_messages(with_instructions: mock_chat, with_temperature: mock_chat,
+                                             with_tools: mock_chat, with_schema: mock_chat)
+        allow(mock_chat).to receive(:with_model).and_return(mock_chat)
+        allow(runner).to receive(:build_agent_tools).with(handoff_agent, context_wrapper).and_return([])
+
+        runner.send(:configure_chat_for_agent, mock_chat, handoff_agent, context_wrapper, replace: true)
+
+        expect(mock_chat).to have_received(:with_model).with(
+          "deployment-name",
+          provider: :azure,
+          assume_exists: true
+        )
       end
 
       it "returns error when handoff to unregistered agent is attempted" do
@@ -1028,6 +1091,8 @@ RSpec.describe Agents::Runner do
         instance_double(Agents::Agent,
                         name: "StructuredAgent",
                         model: "gpt-4o",
+                        provider: nil,
+                        assume_model_exists: false,
                         tools: [],
                         handoff_agents: [],
                         temperature: 0.7,
@@ -1101,6 +1166,8 @@ RSpec.describe Agents::Runner do
         instance_double(Agents::Agent,
                         name: "ToolAgent",
                         model: "gpt-4o",
+                        provider: nil,
+                        assume_model_exists: false,
                         tools: [test_tool],
                         handoff_agents: [],
                         temperature: 0.7,
@@ -1212,6 +1279,8 @@ RSpec.describe Agents::Runner do
         agent_with_handoff = instance_double(Agents::Agent,
                                              name: "TriageAgent",
                                              model: "gpt-4o",
+                                             provider: nil,
+                                             assume_model_exists: false,
                                              tools: [],
                                              handoff_agents: [handoff_agent],
                                              temperature: 0.7,
@@ -1244,6 +1313,8 @@ RSpec.describe Agents::Runner do
         agent_with_handoff = instance_double(Agents::Agent,
                                              name: "TriageAgent",
                                              model: "gpt-4o",
+                                             provider: nil,
+                                             assume_model_exists: false,
                                              tools: [],
                                              handoff_agents: [handoff_agent],
                                              temperature: 0.7,

--- a/spec/agents_spec.rb
+++ b/spec/agents_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe Agents do
     let(:mock_ruby_llm_config) do
       Class.new do
         attr_writer :openai_api_key, :openai_api_base, :openai_organization_id, :openai_project_id,
-                    :anthropic_api_key, :gemini_api_key, :deepseek_api_key, :openrouter_api_key,
-                    :ollama_api_base, :bedrock_api_key, :bedrock_secret_key, :bedrock_region,
-                    :bedrock_session_token, :default_model, :log_level, :request_timeout
-        attr_reader :log_level
+                    :anthropic_api_key, :azure_api_base, :azure_api_key, :azure_ai_auth_token, :gemini_api_key,
+                    :deepseek_api_key, :openrouter_api_key, :ollama_api_base, :bedrock_api_key, :bedrock_secret_key,
+                    :bedrock_region, :bedrock_session_token, :default_model, :log_level, :request_timeout
+        attr_reader :azure_api_base, :azure_api_key, :azure_ai_auth_token, :log_level
       end.new
     end
 
@@ -126,6 +126,9 @@ RSpec.describe Agents do
         config.openai_api_base = "https://custom.openai.com"
         config.openai_organization_id = "org-123"
         config.openai_project_id = "proj-456"
+        config.azure_api_base = "https://example.openai.azure.com"
+        config.azure_api_key = "test-azure-key"
+        config.azure_ai_auth_token = "test-azure-token"
         config.deepseek_api_key = "test-deepseek"
         config.openrouter_api_key = "test-openrouter"
         config.ollama_api_base = "http://localhost:11434"
@@ -136,6 +139,20 @@ RSpec.describe Agents do
       end
 
       expect(RubyLLM).to have_received(:configure)
+    end
+
+    it "applies Azure config fields to RubyLLM config" do
+      allow(RubyLLM).to receive(:configure).and_yield(mock_ruby_llm_config)
+
+      described_class.configure do |config|
+        config.azure_api_base = "https://example.openai.azure.com"
+        config.azure_api_key = "test-azure-key"
+        config.azure_ai_auth_token = "test-azure-token"
+      end
+
+      expect(mock_ruby_llm_config.azure_api_base).to eq("https://example.openai.azure.com")
+      expect(mock_ruby_llm_config.azure_api_key).to eq("test-azure-key")
+      expect(mock_ruby_llm_config.azure_ai_auth_token).to eq("test-azure-token")
     end
   end
 end
@@ -156,6 +173,9 @@ RSpec.describe Agents::Configuration do
       expect(config.openai_organization_id).to be_nil
       expect(config.openai_project_id).to be_nil
       expect(config.anthropic_api_key).to be_nil
+      expect(config.azure_api_base).to be_nil
+      expect(config.azure_api_key).to be_nil
+      expect(config.azure_ai_auth_token).to be_nil
       expect(config.gemini_api_key).to be_nil
       expect(config.deepseek_api_key).to be_nil
       expect(config.openrouter_api_key).to be_nil
@@ -176,6 +196,16 @@ RSpec.describe Agents::Configuration do
     it "allows setting and getting anthropic_api_key" do
       config.anthropic_api_key = "test-anthropic-key"
       expect(config.anthropic_api_key).to eq("test-anthropic-key")
+    end
+
+    it "allows setting and getting Azure config" do
+      config.azure_api_base = "https://example.openai.azure.com"
+      config.azure_api_key = "test-azure-key"
+      config.azure_ai_auth_token = "test-azure-token"
+
+      expect(config.azure_api_base).to eq("https://example.openai.azure.com")
+      expect(config.azure_api_key).to eq("test-azure-key")
+      expect(config.azure_ai_auth_token).to eq("test-azure-token")
     end
 
     it "allows setting and getting gemini_api_key" do
@@ -284,6 +314,18 @@ RSpec.describe Agents::Configuration do
 
     it "returns truthy when bedrock_api_key is set" do
       config.bedrock_api_key = "test-key"
+      expect(config).to be_configured
+    end
+
+    it "returns truthy when Azure API key and base are set" do
+      config.azure_api_base = "https://example.openai.azure.com"
+      config.azure_api_key = "test-key"
+      expect(config).to be_configured
+    end
+
+    it "returns truthy when Azure auth token and base are set" do
+      config.azure_api_base = "https://example.openai.azure.com"
+      config.azure_ai_auth_token = "test-token"
       expect(config).to be_configured
     end
   end


### PR DESCRIPTION
RubyLLM needs a mandatory `provider` argument when we `assume_model_exists` .This is particularly useful for ollama/litellm setups. 

Also supported azure since RubyLLM already supports it