### PR TITLE
fix: per-message agent attribution broken when snapshotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Preserve per-message assistant agent attribution when restoring and snapshotting multi-agent conversation history, preventing earlier assistant messages from being re-labeled as the final active agent after handoffs (#67)
 
 ## [0.10.0] - 2026-04-20
 

--- a/lib/agents/helpers/message_extractor.rb
+++ b/lib/agents/helpers/message_extractor.rb
@@ -20,6 +20,12 @@ module Agents
     module MessageExtractor
       # RubyLLM::Message has no metadata/extension API, so agent ownership is stored
       # as an SDK-namespaced ivar on the message object until it is extracted.
+      #
+      # Caveat: RubyLLM::Message#instance_variables is overridden to hide :@raw but does
+      # not hide this ivar, so it will appear in instance_variables listings. This is
+      # harmless for our own code path (we read it via instance_variable_get and
+      # serialize through extract_messages, not Marshal), but external introspection
+      # of a message's ivars will see :@agents_authoring_agent.
       AUTHORING_AGENT_IVAR = :@agents_authoring_agent
 
       module_function

--- a/lib/agents/helpers/message_extractor.rb
+++ b/lib/agents/helpers/message_extractor.rb
@@ -18,7 +18,23 @@
 module Agents
   module Helpers
     module MessageExtractor
+      # RubyLLM::Message has no metadata/extension API, so agent ownership is stored
+      # as an SDK-namespaced ivar on the message object until it is extracted.
+      AUTHORING_AGENT_IVAR = :@agents_authoring_agent
+
       module_function
+
+      def assign_agent_name(message, agent_name)
+        return unless message && agent_name
+
+        message.instance_variable_set(AUTHORING_AGENT_IVAR, agent_name)
+      end
+
+      def attributed_agent_name_for(message)
+        return unless message&.instance_variable_defined?(AUTHORING_AGENT_IVAR)
+
+        message.instance_variable_get(AUTHORING_AGENT_IVAR)
+      end
 
       # Check if content is considered empty (handles both String and Hash content)
       #
@@ -65,7 +81,8 @@ module Agents
 
         return message unless msg.role == :assistant
 
-        message[:agent_name] = current_agent.name if current_agent
+        attributed_agent_name = attributed_agent_name_for(msg) || current_agent&.name
+        message[:agent_name] = attributed_agent_name if attributed_agent_name
 
         if tool_calls_present
           # RubyLLM stores tool_calls as Hash with call_id => ToolCall object

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -118,6 +118,7 @@ module Agents
         raise MaxTurnsExceeded, "Exceeded maximum turns: #{max_turns}" if current_turn > max_turns
 
         # Get response from LLM (RubyLLM handles tool execution with halting based handoff detection)
+        message_count_before_response = chat_message_count(chat)
         response = if current_turn == 1
                      # Emit agent thinking event for initial message
                      context_wrapper.callback_manager.emit_agent_thinking(current_agent.name, input, context_wrapper)
@@ -130,6 +131,7 @@ module Agents
                                                                           context_wrapper)
                      chat.complete
                    end
+        assign_agent_name_to_new_assistant_messages(chat, current_agent, message_count_before_response)
         track_usage(response, context_wrapper)
 
         # Emit LLM call complete event with model and response for instrumentation
@@ -266,6 +268,7 @@ module Agents
         next unless message_params # Skip invalid messages
 
         message = RubyLLM::Message.new(**message_params)
+        assign_restored_agent_name(message, msg)
         chat.add_message(message)
 
         if message.role == :assistant && message_params[:tool_calls]
@@ -375,6 +378,33 @@ module Agents
 
       # Clean up temporary handoff state
       context_wrapper.context.delete(:pending_handoff)
+    end
+
+    def assign_agent_name_to_new_assistant_messages(chat, current_agent, start_index)
+      # Runtime chats are RubyLLM::Chat instances and expose messages. Keep this
+      # no-op guard for chat-like doubles/adapters that do not expose history.
+      return unless chat.respond_to?(:messages)
+
+      chat.messages[start_index..]&.each do |message|
+        next unless message.role == :assistant
+
+        Helpers::MessageExtractor.assign_agent_name(message, current_agent.name)
+      end
+    end
+
+    def chat_message_count(chat)
+      # Runtime chats are RubyLLM::Chat instances and expose messages. Keep this
+      # fallback for chat-like doubles/adapters where attribution is irrelevant.
+      return 0 unless chat.respond_to?(:messages)
+
+      chat.messages.length
+    end
+
+    def assign_restored_agent_name(message, msg)
+      return unless message.role == :assistant
+
+      restored_agent_name = msg[:agent_name] || msg["agent_name"]
+      Helpers::MessageExtractor.assign_agent_name(message, restored_agent_name)
     end
 
     # Configures a RubyLLM chat instance with agent-specific settings.

--- a/spec/agents/helpers/message_extractor_spec.rb
+++ b/spec/agents/helpers/message_extractor_spec.rb
@@ -5,6 +5,40 @@ require "spec_helper"
 RSpec.describe Agents::Helpers::MessageExtractor do
   let(:current_agent) { instance_double(Agents::Agent, name: "TestAgent") }
 
+  describe ".assign_agent_name" do
+    let(:message) do
+      instance_double(RubyLLM::Message,
+                      role: :assistant,
+                      content: "I'll route this.",
+                      tool_call?: false,
+                      tool_calls: nil)
+    end
+
+    it "stores attribution that extraction can read back" do
+      described_class.assign_agent_name(message, "Triage")
+
+      result = described_class.extract_messages(instance_double(RubyLLM::Chat, messages: [message]), current_agent)
+
+      expect(result).to eq([
+                             {
+                               role: :assistant,
+                               content: "I'll route this.",
+                               agent_name: "Triage"
+                             }
+                           ])
+    end
+
+    it "does nothing when message is nil" do
+      expect { described_class.assign_agent_name(nil, "Triage") }.not_to raise_error
+    end
+
+    it "does nothing when agent name is nil" do
+      described_class.assign_agent_name(message, nil)
+
+      expect(described_class.attributed_agent_name_for(message)).to be_nil
+    end
+  end
+
   describe ".extract_messages" do
     context "when chat has no messages method" do
       let(:chat) { double("chat without messages") }
@@ -204,6 +238,48 @@ RSpec.describe Agents::Helpers::MessageExtractor do
                                      arguments: { foo: "bar" }
                                    }
                                  ]
+                               }
+                             ])
+      end
+    end
+
+    context "when assistant messages have per-message agent attribution" do
+      let(:triage_message) do
+        instance_double(RubyLLM::Message,
+                        role: :assistant,
+                        content: "I'll route this.",
+                        tool_call?: false,
+                        tool_calls: nil)
+      end
+
+      let(:specialist_message) do
+        instance_double(RubyLLM::Message,
+                        role: :assistant,
+                        content: "I can help with your invoice.",
+                        tool_call?: false,
+                        tool_calls: nil)
+      end
+
+      let(:chat) { instance_double(RubyLLM::Chat, messages: [triage_message, specialist_message]) }
+
+      before do
+        described_class.assign_agent_name(triage_message, "Triage")
+        described_class.assign_agent_name(specialist_message, "Billing")
+      end
+
+      it "uses stored per-message attribution instead of the current agent" do
+        result = described_class.extract_messages(chat, current_agent)
+
+        expect(result).to eq([
+                               {
+                                 role: :assistant,
+                                 content: "I'll route this.",
+                                 agent_name: "Triage"
+                               },
+                               {
+                                 role: :assistant,
+                                 content: "I can help with your invoice.",
+                                 agent_name: "Billing"
                                }
                              ])
       end

--- a/spec/agents/runner_spec.rb
+++ b/spec/agents/runner_spec.rb
@@ -267,6 +267,22 @@ RSpec.describe Agents::Runner do
         expect(result.messages.length).to eq(4) # 2 from history + 2 new
       end
 
+      it "preserves restored assistant agent attribution" do
+        context = {
+          conversation_history: [
+            { role: :user, content: "I need help with billing" },
+            { role: :assistant, content: "I'll route this.", agent_name: "TriageAgent" }
+          ]
+        }
+
+        result = runner.run(agent, "Thanks for routing me", context: context)
+
+        expect(result.context[:conversation_history]).to include(
+          hash_including(content: "I'll route this.", agent_name: "TriageAgent"),
+          hash_including(content: "Yes, that's correct! Is there anything else?", agent_name: "TestAgent")
+        )
+      end
+
       context "with string roles in history" do
         let(:context_with_string_roles) do
           {
@@ -861,7 +877,8 @@ RSpec.describe Agents::Runner do
         # First request - triage agent decides to handoff
         # After handoff, the specialist agent responds
         stub_chat_sequence(
-          { tool_calls: [{ name: "handoff_to_handoffagent", arguments: "{}" }] },
+          { content: "I'll route this to a specialist.",
+            tool_calls: [{ name: "handoff_to_handoffagent", arguments: "{}" }] },
           "Hello, I'm the specialist. How can I help?"
         )
       end
@@ -873,6 +890,18 @@ RSpec.describe Agents::Runner do
         expect(result.success?).to be true
         expect(result.output).to eq("Hello, I'm the specialist. How can I help?")
         expect(result.context[:current_agent]).to eq("HandoffAgent")
+      end
+
+      it "preserves assistant attribution across handoff snapshots" do
+        registry = { "TriageAgent" => agent_with_handoffs, "HandoffAgent" => handoff_agent }
+        result = runner.run(agent_with_handoffs, "I need specialist help", registry: registry)
+
+        assistant_messages = result.context[:conversation_history].select { |msg| msg[:role] == :assistant }
+
+        expect(assistant_messages).to include(
+          hash_including(content: "I'll route this to a specialist.", agent_name: "TriageAgent"),
+          hash_including(content: "Hello, I'm the specialist. How can I help?", agent_name: "HandoffAgent")
+        )
       end
 
       it "returns error when handoff to unregistered agent is attempted" do

--- a/spec/integration/live_handoff_spec.rb
+++ b/spec/integration/live_handoff_spec.rb
@@ -35,4 +35,36 @@ RSpec.describe "Live agent handoff", :live_llm do
     expect(result.context[:current_agent]).to eq("Specialist")
     expect(result.output).to match(/ready/i)
   end
+
+  it "preserves restored assistant attribution after a later handoff" do
+    specialist = Agents::Agent.new(
+      name: "Specialist",
+      instructions: "You only respond with the single word SPECIALIST_READY when a conversation is transferred to you.",
+      model: model,
+      temperature: 0
+    )
+
+    triage = Agents::Agent.new(
+      name: "Triage",
+      instructions: "If the user asks for the triage marker, respond only TRIAGE_MARKER and do not call tools. " \
+                    "If the user asks to transfer, immediately call the handoff tool to Specialist.",
+      model: model,
+      handoff_agents: [specialist],
+      temperature: 0
+    )
+
+    runner = Agents::Runner.with_agents(triage, specialist)
+    triage_result = runner.run("Please provide the triage marker.")
+    handoff_result = runner.run("Please transfer me now.", context: triage_result.context)
+
+    history = handoff_result.context[:conversation_history]
+    triage_message = history.find { |msg| msg[:role] == :assistant && msg[:content].to_s.match?(/TRIAGE_MARKER/i) }
+    specialist_message = history.reverse.find { |msg| msg[:role] == :assistant }
+
+    expect(triage_result.error).to be_nil
+    expect(handoff_result.error).to be_nil
+    expect(handoff_result.context[:current_agent]).to eq("Specialist")
+    expect(triage_message).to include(agent_name: "Triage")
+    expect(specialist_message).to include(agent_name: "Specialist")
+  end
 end

--- a/spec/support/openai_test_helper.rb
+++ b/spec/support/openai_test_helper.rb
@@ -93,7 +93,7 @@ module OpenAITestHelper
       current_stub = if response.is_a?(String)
                        build_simple_response(response)
                      elsif response[:tool_calls]
-                       build_tool_call_response(response[:tool_calls])
+                       build_tool_call_response(response[:tool_calls], content: response[:content])
                      else
                        build_simple_response(response[:content] || "Response", response)
                      end
@@ -147,7 +147,7 @@ module OpenAITestHelper
     }
   end
 
-  def build_tool_call_response(tool_calls)
+  def build_tool_call_response(tool_calls, content: nil)
     formatted_tool_calls = tool_calls.map do |call|
       {
         id: call[:id] || "call_#{SecureRandom.hex(4)}",
@@ -168,7 +168,7 @@ module OpenAITestHelper
         index: 0,
         message: {
           role: "assistant",
-          content: nil,
+          content: content,
           tool_calls: formatted_tool_calls
         },
         finish_reason: "tool_calls"


### PR DESCRIPTION
In multi-agent conversations, `MessageExtractor.extract_messages` stamps every assistant message with the *currently active* agent's name. After a handoff, the chat contains assistant messages produced by earlier agents, but snapshotting the chat under the final agent re-attributes all of them to that final agent.

That polluted snapshot then leaks into `AgentRunner#determine_conversation_agent`, which picks the next active agent from the last assistant message's `agent_name` — so subsequent runs can start with the wrong specialist.

Example of the broken snapshot after a `Triage → Billing` handoff:

```ruby
[
  { role: :user, content: "I need help with billing" },
  { role: :assistant, content: "I'll route this.",            agent_name: "Billing" }, # wrong
  { role: :assistant, content: "I can help with your invoice.", agent_name: "Billing" }
]
```
Fixes #67.

## Fix

Attach agent ownership to each assistant message at the moment it is produced, then read that per-message attribution at extraction time instead of inferring it from `current_agent`.

`RubyLLM::Message` has no metadata/extension API, so attribution is stored as an SDK-namespaced instance variable (`:@agents_authoring_agent`) on the message object. Two new module functions on `MessageExtractor` encapsulate this storage:

- `assign_agent_name(message, agent_name)` — stamp a message.
- `attributed_agent_name_for(message)` — read the stamp back.

`Runner` calls `assign_agent_name` in two places:

1. After every `chat.ask` / `chat.complete` round trip, on the assistant messages appended during that turn (`assign_agent_name_to_new_assistant_messages`).
2. When restoring messages from `context[:conversation_history]`, preserving any prior `agent_name` (`assign_restored_agent_name`).

`MessageExtractor.extract_user_or_assistant_message` now reads `attributed_agent_name_for(msg)` first and falls back to `current_agent.name` only when no per-message attribution exists. This keeps legacy/un-tagged history backwards compatible.

## Result

```ruby
[
  { role: :user, content: "I need help with billing" },
  { role: :assistant, content: "I'll route this.",            agent_name: "Triage" },
  { role: :assistant, content: "I can help with your invoice.", agent_name: "Billing" }
]
```