### PR TITLE
Document Tuning Engines endpoint for Rails agents

### DIFF
--- a/docs/guides/rails-integration.md
+++ b/docs/guides/rails-integration.md
@@ -32,6 +32,19 @@ Agents.configure do |config|
 end
 ```
 
+Rails apps that already use OpenAI-compatible endpoints can also route agent calls through a governed control plane such as [Tuning Engines](https://www.tuningengines.com/):
+
+```ruby
+# config/initializers/ai_agents.rb
+Agents.configure do |config|
+  config.openai_api_key = Rails.application.credentials.dig(:tuning_engines, :api_key)
+  config.openai_api_base = "https://api.tuningengines.com/v1"
+  config.default_model = "gpt-4o-mini"
+end
+```
+
+This keeps AI Agents responsible for orchestration, handoffs, tools, and Rails persistence while the gateway centralizes routing, policy controls, audit logs, traces, approvals, and cost visibility.
+
 For Azure custom deployment names, pass the provider at the agent level:
 
 ```ruby


### PR DESCRIPTION
## Summary

- Adds a small documentation example for using Tuning Engines through the existing OpenAI-compatible configuration surface.
- Keeps the project API unchanged: no dependencies, no adapter changes, and no runtime behavior changes.
- Shows how Ruby/Rails teams can keep this project in charge of application, agent, tool, or workflow logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI application code.

This project already supports OpenAI-compatible configuration. The docs change makes that existing capability discoverable for Ruby/Rails teams without asking the project to add a new provider, dependency, SDK, or runtime integration.

## Testing

- `git diff --check`
