### PR TITLE
chore: route live LLM smoke suite through OpenRouter

### DIFF
--- a/.github/workflows/live_llm.yml
+++ b/.github/workflows/live_llm.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      model:
+        description: "OpenRouter model id to run the smoke suite against (overrides the default)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -16,8 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUN_LIVE_LLM: "true"
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      # OpenRouter model. Defaults to the namespaced openai/gpt-4.1-nano, which
+      # resolves to the :openrouter provider and supports tool calling and
+      # vision for the full live suite. Override per-run via the workflow_dispatch
+      # input, or persistently via an OPENROUTER_MODEL repo variable.
+      OPENROUTER_MODEL: ${{ inputs.model || vars.OPENROUTER_MODEL || 'openai/gpt-4.1-nano' }}
       LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
       LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
       LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
@@ -32,8 +41,8 @@ jobs:
 
       - name: Verify secrets
         run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "OPENAI_API_KEY is not configured; live LLM smoke tests skipped." >&2
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            echo "OPENROUTER_API_KEY is not configured; live LLM smoke tests skipped." >&2
             exit 1
           fi
 

--- a/spec/integration/live_agent_as_tool_spec.rb
+++ b/spec/integration/live_agent_as_tool_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Live agent as tool", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "delegates through agent-as-tool and returns nested output" do

--- a/spec/integration/live_handoff_spec.rb
+++ b/spec/integration/live_handoff_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Live agent handoff", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "hands off to the target agent and continues the conversation" do

--- a/spec/integration/live_instrumentation_spec.rb
+++ b/spec/integration/live_instrumentation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Live instrumentation smoke test", :live_llm do
   let(:in_memory_exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
     configure_otel(in_memory_exporter)
   end
 

--- a/spec/integration/live_multimodal_history_spec.rb
+++ b/spec/integration/live_multimodal_history_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Live LLM multimodal history", :live_llm do
   end
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "restores image content from conversation history and references it" do

--- a/spec/integration/live_params_spec.rb
+++ b/spec/integration/live_params_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Live params passthrough", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   context "with runtime params" do

--- a/spec/integration/live_response_schema_spec.rb
+++ b/spec/integration/live_response_schema_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Live response schema enforcement", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "returns JSON that matches a simple schema" do

--- a/spec/integration/live_runner_basic_spec.rb
+++ b/spec/integration/live_runner_basic_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Live LLM basic runner", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "returns a deterministic single-word reply" do

--- a/spec/integration/live_runner_tool_call_spec.rb
+++ b/spec/integration/live_runner_tool_call_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Live LLM tool call", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "invokes a simple tool and returns its result" do

--- a/spec/integration/live_usage_spec.rb
+++ b/spec/integration/live_usage_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Live usage accounting", :live_llm do
   let(:model) { live_model }
 
   before do
-    configure_live_llm(model: ENV.fetch("OPENAI_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
+    configure_live_llm(model: ENV.fetch("OPENROUTER_MODEL", LiveLLMHelper::DEFAULT_LIVE_MODEL))
   end
 
   it "returns prompt and completion token counts" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,14 +35,14 @@ RSpec.configure do |config|
 
   # Only run live LLM specs (tagged :live_llm) when explicitly enabled with credentials.
   # Prevents accidental real API calls in local/PR runs.
-  unless ENV["RUN_LIVE_LLM"] && ENV["OPENAI_API_KEY"]
+  unless ENV["RUN_LIVE_LLM"] && ENV["OPENROUTER_API_KEY"]
     config.filter_run_excluding :live_llm
   end
 
   # Even if someone force-includes the tag, guard at runtime to avoid config errors.
   config.before(:each, :live_llm) do
-    unless ENV["RUN_LIVE_LLM"] && ENV["OPENAI_API_KEY"]
-      skip "Live LLM specs require RUN_LIVE_LLM=true and OPENAI_API_KEY set"
+    unless ENV["RUN_LIVE_LLM"] && ENV["OPENROUTER_API_KEY"]
+      skip "Live LLM specs require RUN_LIVE_LLM=true and OPENROUTER_API_KEY set"
     end
   end
 

--- a/spec/support/live_llm_helper.rb
+++ b/spec/support/live_llm_helper.rb
@@ -2,19 +2,25 @@
 
 # Helper utilities for running live LLM integration specs.
 # These specs are tagged :live_llm and only run when explicitly enabled.
+# Requests route through OpenRouter; the namespaced model id (e.g. "openai/gpt-4.1-nano")
+# resolves uniquely to RubyLLM's :openrouter provider in the model registry.
 module LiveLLMHelper
-  DEFAULT_LIVE_MODEL = "gpt-4.1-nano"
+  DEFAULT_LIVE_MODEL = "openai/gpt-4.1-nano"
 
   def configure_live_llm(model: live_model)
     Agents.configure do |config|
-      config.openai_api_key = ENV["OPENAI_API_KEY"]
+      config.openrouter_api_key = ENV["OPENROUTER_API_KEY"]
       config.default_model = model
-      config.request_timeout = Integer(ENV.fetch("OPENAI_REQUEST_TIMEOUT", 30))
+      config.request_timeout = Integer(ENV.fetch("OPENROUTER_REQUEST_TIMEOUT", 30))
       config.debug = false
     end
   end
 
   def live_model
-    ENV.fetch("OPENAI_MODEL", DEFAULT_LIVE_MODEL)
+    ENV.fetch("OPENROUTER_MODEL", DEFAULT_LIVE_MODEL)
+  end
+
+  def live_provider
+    :openrouter
   end
 end


### PR DESCRIPTION
Switches the live LLM smoke suite from direct OpenAI to OpenRouter: `LiveLLMHelper` now uses `openrouter_api_key` and the namespaced default `openai/gpt-4.1-nano` (resolves uniquely to RubyLLM's `:openrouter` provider), with env knobs and the `spec_helper` gate renamed to `OPENROUTER_*`. CI uses the `OPENROUTER_API_KEY` secret and an `OPENROUTER_MODEL` that's overridable via a `workflow_dispatch` input or repo variable, defaulting to the hardcoded model.

