### PR TITLE
feat: propagate Langfuse metadata to child spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-29
+
+### Added
+- Propagate Langfuse trace metadata and filter attributes from root traces to child agent, tool, and generation spans, while keeping span-specific input/output attributes local to each span.
+- Support optional generation-level attributes via `attribute_provider#generation_attributes(context_wrapper, chat, message)`.
+
 ## [0.11.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Propagate Langfuse trace metadata and filter attributes from root traces to child agent, tool, and generation spans, while keeping span-specific input/output attributes local to each span.
 - Support optional generation-level attributes via `attribute_provider#generation_attributes(context_wrapper, chat, message)`.
+- Add `gen_ai.request.temperature` to generation spans when an agent temperature is configured.
 
 ## [0.11.0] - 2026-05-27
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-agents (0.11.0)
+    ai-agents (0.12.0)
       ruby_llm (~> 1.14)
 
 GEM

--- a/lib/agents/instrumentation.rb
+++ b/lib/agents/instrumentation.rb
@@ -34,6 +34,22 @@ module Agents
   #       { 'langfuse.user.id' => ctx.context[:account_id].to_s }
   #     }
   #   )
+  #
+  # @example With custom generation attributes
+  #   class MyAttributeProvider
+  #     def call(ctx)
+  #       { 'langfuse.user.id' => ctx.context[:account_id].to_s }
+  #     end
+  #
+  #     def generation_attributes(_ctx, _chat, message)
+  #       { 'app.generation.has_tool_calls' => message.tool_calls&.any? }
+  #     end
+  #   end
+  #
+  #   Agents::Instrumentation.install(runner,
+  #     tracer: tracer,
+  #     attribute_provider: MyAttributeProvider.new
+  #   )
   module Instrumentation
     INSTALL_MUTEX = Mutex.new
     private_constant :INSTALL_MUTEX
@@ -52,7 +68,9 @@ module Agents
     # @param tracer [OpenTelemetry::Trace::Tracer] OTel tracer instance
     # @param trace_name [String] Name for the root span (default: "agents.run")
     # @param span_attributes [Hash] Static attributes applied to the root span
-    # @param attribute_provider [Proc, nil] Lambda receiving context_wrapper, returning dynamic attributes
+    # @param attribute_provider [#call, nil] Object receiving context_wrapper and returning dynamic root attributes.
+    #   If it also responds to #generation_attributes, that method receives context_wrapper, chat, and message,
+    #   and can return dynamic attributes for generation spans.
     # @return [Agents::AgentRunner, nil] The runner (for chaining), or nil if OTel is unavailable
     def self.install(runner, tracer:, trace_name: Constants::SPAN_RUN, span_attributes: {},
                      attribute_provider: nil)

--- a/lib/agents/instrumentation/constants.rb
+++ b/lib/agents/instrumentation/constants.rb
@@ -25,11 +25,13 @@ module Agents
       ATTR_LANGFUSE_TRACE_TAGS  = "langfuse.trace.tags"
       ATTR_LANGFUSE_TRACE_INPUT = "langfuse.trace.input"
       ATTR_LANGFUSE_TRACE_OUTPUT = "langfuse.trace.output"
+      ATTR_LANGFUSE_TRACE_METADATA_PREFIX = "langfuse.trace.metadata."
 
       # Langfuse observation-level attributes
       ATTR_LANGFUSE_OBS_TYPE   = "langfuse.observation.type"
       ATTR_LANGFUSE_OBS_INPUT  = "langfuse.observation.input"
       ATTR_LANGFUSE_OBS_OUTPUT = "langfuse.observation.output"
+      ATTR_LANGFUSE_OBS_METADATA_PREFIX = "langfuse.observation.metadata."
     end
   end
 end

--- a/lib/agents/instrumentation/constants.rb
+++ b/lib/agents/instrumentation/constants.rb
@@ -22,6 +22,7 @@ module Agents
       # Langfuse trace-level attributes
       ATTR_LANGFUSE_USER_ID     = "langfuse.user.id"
       ATTR_LANGFUSE_SESSION_ID  = "langfuse.session.id"
+      ATTR_LANGFUSE_PREFIX      = "langfuse."
       ATTR_LANGFUSE_TRACE_TAGS  = "langfuse.trace.tags"
       ATTR_LANGFUSE_TRACE_INPUT = "langfuse.trace.input"
       ATTR_LANGFUSE_TRACE_OUTPUT = "langfuse.trace.output"

--- a/lib/agents/instrumentation/constants.rb
+++ b/lib/agents/instrumentation/constants.rb
@@ -15,6 +15,7 @@ module Agents
 
       # GenAI semantic conventions (ONLY on generation spans)
       ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+      ATTR_GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
       ATTR_GEN_AI_PROVIDER      = "gen_ai.provider.name"
       ATTR_GEN_AI_USAGE_INPUT   = "gen_ai.usage.input_tokens"
       ATTR_GEN_AI_USAGE_OUTPUT  = "gen_ai.usage.output_tokens"

--- a/lib/agents/instrumentation/tracing_callbacks.rb
+++ b/lib/agents/instrumentation/tracing_callbacks.rb
@@ -18,6 +18,15 @@ module Agents
     class TracingCallbacks
       include Constants
 
+      CHILD_LANGFUSE_EXCLUDED_ATTRIBUTES = [
+        ATTR_LANGFUSE_TRACE_INPUT,
+        ATTR_LANGFUSE_TRACE_OUTPUT,
+        ATTR_LANGFUSE_OBS_INPUT,
+        ATTR_LANGFUSE_OBS_OUTPUT,
+        ATTR_LANGFUSE_OBS_TYPE
+      ].freeze
+      private_constant :CHILD_LANGFUSE_EXCLUDED_ATTRIBUTES
+
       def initialize(tracer:, trace_name: SPAN_RUN, span_attributes: {}, attribute_provider: nil)
         @tracer = tracer
         @trace_name = trace_name
@@ -315,17 +324,22 @@ module Agents
       def build_child_langfuse_attributes(root_attributes)
         root_attributes.each_with_object({}) do |(key, value), attrs|
           next if value.nil?
+          next unless child_langfuse_attribute?(key)
 
-          if propagated_trace_attribute?(key)
-            attrs[key] = value
-            add_observation_metadata_mirror(attrs, key, value)
-          elsif key.start_with?(ATTR_LANGFUSE_OBS_METADATA_PREFIX)
-            attrs[key] = value
-          end
+          attrs[key] = value
+          add_observation_metadata_mirror(attrs, key, value) if mirrored_observation_metadata_attribute?(key)
         end
       end
 
-      def propagated_trace_attribute?(key)
+      def child_langfuse_attribute?(key)
+        key.start_with?(ATTR_LANGFUSE_PREFIX) && !child_langfuse_excluded_attribute?(key)
+      end
+
+      def child_langfuse_excluded_attribute?(key)
+        CHILD_LANGFUSE_EXCLUDED_ATTRIBUTES.include?(key)
+      end
+
+      def mirrored_observation_metadata_attribute?(key)
         key == ATTR_LANGFUSE_USER_ID ||
           key == ATTR_LANGFUSE_SESSION_ID ||
           key == ATTR_LANGFUSE_TRACE_TAGS ||
@@ -333,18 +347,21 @@ module Agents
       end
 
       def add_observation_metadata_mirror(attrs, key, value)
-        metadata_key = case key
-                       when ATTR_LANGFUSE_USER_ID
-                         "user_id"
-                       when ATTR_LANGFUSE_SESSION_ID
-                         "session_id"
-                       when ATTR_LANGFUSE_TRACE_TAGS
-                         "trace_tags"
-                       else
-                         key.delete_prefix(ATTR_LANGFUSE_TRACE_METADATA_PREFIX)
-                       end
-
+        metadata_key = observation_metadata_mirror_key(key)
         attrs[observation_metadata_key(metadata_key)] = serialize_metadata_value(value)
+      end
+
+      def observation_metadata_mirror_key(key)
+        case key
+        when ATTR_LANGFUSE_USER_ID
+          "user_id"
+        when ATTR_LANGFUSE_SESSION_ID
+          "session_id"
+        when ATTR_LANGFUSE_TRACE_TAGS
+          "trace_tags"
+        else
+          key.delete_prefix(ATTR_LANGFUSE_TRACE_METADATA_PREFIX)
+        end
       end
 
       def observation_metadata_key(key)

--- a/lib/agents/instrumentation/tracing_callbacks.rb
+++ b/lib/agents/instrumentation/tracing_callbacks.rb
@@ -31,6 +31,7 @@ module Agents
 
       def on_run_start(agent_name, input, context_wrapper)
         attributes = build_root_attributes(agent_name, input, context_wrapper)
+        child_attributes = build_child_langfuse_attributes(attributes)
 
         root_span = @tracer.start_span(@trace_name, attributes: attributes)
         root_context = OpenTelemetry::Trace.context_with_span(root_span)
@@ -38,6 +39,7 @@ module Agents
         store_tracing_state(context_wrapper,
                             root_span: root_span,
                             root_context: root_context,
+                            child_langfuse_attributes: child_attributes,
                             current_tool_span: nil,
                             current_agent_name: nil,
                             current_agent_span: nil,
@@ -84,6 +86,7 @@ module Agents
           ATTR_LANGFUSE_OBS_TYPE => "tool",
           ATTR_LANGFUSE_OBS_INPUT => serialize_output(args)
         }
+        attributes.merge!(tracing[:child_langfuse_attributes])
 
         parent = handoff_tool?(tool_name) ? tracing[:root_context] : parent_context(tracing)
         tool_span = @tracer.start_span(
@@ -145,10 +148,11 @@ module Agents
         tracing = tracing_state(context_wrapper)
         return unless tracing
 
-        input = format_chat_messages(chat)
-        attrs = {}
-        attrs[ATTR_LANGFUSE_OBS_INPUT] = input if input
-        llm_span = @tracer.start_span(@llm_span_name, with_parent: parent_context(tracing), attributes: attrs)
+        llm_span = @tracer.start_span(
+          @llm_span_name,
+          with_parent: parent_context(tracing),
+          attributes: generation_span_attributes(tracing, chat, message, context_wrapper)
+        )
 
         llm_span.set_attribute(ATTR_GEN_AI_REQUEST_MODEL, model) if model
 
@@ -157,6 +161,14 @@ module Agents
         tracing[:last_agent_output] = output unless output.empty?
 
         llm_span.finish
+      end
+
+      def generation_span_attributes(tracing, chat, message, context_wrapper)
+        attrs = tracing[:child_langfuse_attributes].dup
+        input = format_chat_messages(chat)
+        attrs[ATTR_LANGFUSE_OBS_INPUT] = input if input
+        apply_generation_dynamic_attributes(attrs, context_wrapper, chat, message)
+        attrs
       end
 
       def finish_dangling_spans(tracing)
@@ -250,19 +262,22 @@ module Agents
         finish_agent_span(tracing) # close previous agent span if missed
 
         span_name = format(@agent_span_name, agent_name)
-        attrs = { "agent.name" => agent_name }
-        input = tracing[:pending_llm_input]
-        attrs[ATTR_LANGFUSE_OBS_INPUT] = input if input && !input.empty?
-
         agent_span = @tracer.start_span(span_name,
                                         with_parent: tracing[:root_context],
-                                        attributes: attrs)
+                                        attributes: agent_span_attributes(tracing, agent_name))
         agent_context = OpenTelemetry::Trace.context_with_span(agent_span)
 
         tracing[:current_agent_name] = agent_name
         tracing[:current_agent_span] = agent_span
         tracing[:current_agent_context] = agent_context
         tracing[:last_agent_output] = nil
+      end
+
+      def agent_span_attributes(tracing, agent_name)
+        attrs = tracing[:child_langfuse_attributes].merge("agent.name" => agent_name)
+        input = tracing[:pending_llm_input]
+        attrs[ATTR_LANGFUSE_OBS_INPUT] = input if input && !input.empty?
+        attrs
       end
 
       def finish_agent_span(tracing)
@@ -297,6 +312,49 @@ module Agents
         attributes
       end
 
+      def build_child_langfuse_attributes(root_attributes)
+        root_attributes.each_with_object({}) do |(key, value), attrs|
+          next if value.nil?
+
+          if propagated_trace_attribute?(key)
+            attrs[key] = value
+            add_observation_metadata_mirror(attrs, key, value)
+          elsif key.start_with?(ATTR_LANGFUSE_OBS_METADATA_PREFIX)
+            attrs[key] = value
+          end
+        end
+      end
+
+      def propagated_trace_attribute?(key)
+        key == ATTR_LANGFUSE_USER_ID ||
+          key == ATTR_LANGFUSE_SESSION_ID ||
+          key == ATTR_LANGFUSE_TRACE_TAGS ||
+          key.start_with?(ATTR_LANGFUSE_TRACE_METADATA_PREFIX)
+      end
+
+      def add_observation_metadata_mirror(attrs, key, value)
+        metadata_key = case key
+                       when ATTR_LANGFUSE_USER_ID
+                         "user_id"
+                       when ATTR_LANGFUSE_SESSION_ID
+                         "session_id"
+                       when ATTR_LANGFUSE_TRACE_TAGS
+                         "trace_tags"
+                       else
+                         key.delete_prefix(ATTR_LANGFUSE_TRACE_METADATA_PREFIX)
+                       end
+
+        attrs[observation_metadata_key(metadata_key)] = serialize_metadata_value(value)
+      end
+
+      def observation_metadata_key(key)
+        "#{ATTR_LANGFUSE_OBS_METADATA_PREFIX}#{key}"
+      end
+
+      def serialize_metadata_value(value)
+        value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value.to_s
+      end
+
       def apply_session_id(attributes, context_wrapper)
         session_id = context_wrapper&.context&.dig(:session_id)&.to_s
         attributes[ATTR_LANGFUSE_SESSION_ID] = session_id if session_id && !session_id.empty?
@@ -314,6 +372,13 @@ module Agents
         return unless @attribute_provider
 
         dynamic_attrs = @attribute_provider.call(context_wrapper)
+        attributes.merge!(dynamic_attrs) if dynamic_attrs.is_a?(Hash)
+      end
+
+      def apply_generation_dynamic_attributes(attributes, context_wrapper, chat, message)
+        return unless @attribute_provider.respond_to?(:generation_attributes)
+
+        dynamic_attrs = @attribute_provider.generation_attributes(context_wrapper, chat, message)
         attributes.merge!(dynamic_attrs) if dynamic_attrs.is_a?(Hash)
       end
 

--- a/lib/agents/instrumentation/tracing_callbacks.rb
+++ b/lib/agents/instrumentation/tracing_callbacks.rb
@@ -77,12 +77,14 @@ module Agents
         finish_agent_span(tracing)
       end
 
-      def on_chat_created(chat, agent_name, model, context_wrapper)
+      def on_chat_created(chat, agent_name, model, context_wrapper, temperature = nil)
         tracing = tracing_state(context_wrapper)
         return unless tracing
 
+        request_attributes = { model: model, temperature: temperature }
+
         chat.on_end_message do |message|
-          handle_end_message(chat, agent_name, model, message, context_wrapper)
+          handle_end_message(chat, agent_name, request_attributes, message, context_wrapper)
         end
       end
 
@@ -151,7 +153,7 @@ module Agents
 
       private
 
-      def handle_end_message(chat, _agent_name, model, message, context_wrapper)
+      def handle_end_message(chat, _agent_name, request_attributes, message, context_wrapper)
         return unless message.respond_to?(:role) && message.role == :assistant
 
         tracing = tracing_state(context_wrapper)
@@ -163,7 +165,7 @@ module Agents
           attributes: generation_span_attributes(tracing, chat, message, context_wrapper)
         )
 
-        llm_span.set_attribute(ATTR_GEN_AI_REQUEST_MODEL, model) if model
+        set_llm_request_attributes(llm_span, request_attributes)
 
         output = llm_output_text(message)
         set_llm_response_attributes(llm_span, message, output)
@@ -178,6 +180,14 @@ module Agents
         attrs[ATTR_LANGFUSE_OBS_INPUT] = input if input
         apply_generation_dynamic_attributes(attrs, context_wrapper, chat, message)
         attrs
+      end
+
+      def set_llm_request_attributes(span, request_attributes)
+        model = request_attributes[:model]
+        temperature = request_attributes[:temperature]
+
+        span.set_attribute(ATTR_GEN_AI_REQUEST_MODEL, model) if model
+        span.set_attribute(ATTR_GEN_AI_REQUEST_TEMPERATURE, temperature) unless temperature.nil?
       end
 
       def finish_dangling_spans(tracing)

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -115,7 +115,9 @@ module Agents
       configure_chat_for_agent(chat, current_agent, context_wrapper, replace: false)
       restore_conversation_history(chat, context_wrapper)
       input_already_in_history = last_message_matches?(chat, input)
-      context_wrapper.callback_manager.emit_chat_created(chat, current_agent.name, current_agent.model, context_wrapper)
+      context_wrapper.callback_manager.emit_chat_created(
+        chat, current_agent.name, current_agent.model, context_wrapper, current_agent.temperature
+      )
 
       loop do
         current_turn += 1
@@ -178,7 +180,7 @@ module Agents
           current_params = Helpers::HashNormalizer.merge(agent_params, runtime_params)
           apply_params(chat, current_params)
           context_wrapper.callback_manager.emit_chat_created(
-            chat, current_agent.name, current_agent.model, context_wrapper
+            chat, current_agent.name, current_agent.model, context_wrapper, current_agent.temperature
           )
 
           # Force the new agent to respond to the conversation context

--- a/lib/agents/version.rb
+++ b/lib/agents/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Agents
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end

--- a/spec/agents/instrumentation/tracing_callbacks_spec.rb
+++ b/spec/agents/instrumentation/tracing_callbacks_spec.rb
@@ -567,6 +567,14 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
       expect(llm_span).to have_received(:finish)
     end
 
+    it "sets request temperature on generation spans when provided" do
+      allow(tracer).to receive(:start_span).and_return(llm_span)
+
+      callbacks.on_chat_created(chat, "TestAgent", "gpt-4o", context_wrapper, 0.2)
+
+      expect(llm_span).to have_received(:set_attribute).with("gen_ai.request.temperature", 0.2)
+    end
+
     it "propagates root Langfuse metadata to LLM generation spans" do
       cb = callbacks_with_langfuse_metadata
       fresh_context = build_context(session_id: "acct_1_conv_2")
@@ -739,6 +747,15 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
         callbacks.on_chat_created(chat, "TestAgent", nil, context_wrapper)
 
         expect(llm_span).not_to have_received(:set_attribute).with("gen_ai.request.model", anything)
+      end
+
+      it "skips setting temperature attribute when temperature is nil" do
+        allow(chat).to receive(:on_end_message).and_yield(assistant_message)
+        allow(tracer).to receive(:start_span).and_return(llm_span)
+
+        callbacks.on_chat_created(chat, "TestAgent", "gpt-4o", context_wrapper)
+
+        expect(llm_span).not_to have_received(:set_attribute).with("gen_ai.request.temperature", anything)
       end
     end
 

--- a/spec/agents/instrumentation/tracing_callbacks_spec.rb
+++ b/spec/agents/instrumentation/tracing_callbacks_spec.rb
@@ -76,7 +76,10 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
     lambda do |_ctx|
       {
         "langfuse.user.id" => "user_42",
-        "langfuse.trace.metadata.assistant_id" => "123"
+        "langfuse.trace.metadata.assistant_id" => "123",
+        "langfuse.release" => "2026.06.29",
+        "langfuse.version" => "sha-abc123",
+        "langfuse.observation.type" => "should_not_propagate"
       }
     end
   end
@@ -172,12 +175,16 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
         "langfuse.session.id" => "acct_1_conv_2",
         "langfuse.trace.tags" => ["captain_v2"],
         "langfuse.trace.metadata.assistant_id" => "123",
+        "langfuse.release" => "2026.06.29",
+        "langfuse.version" => "sha-abc123",
         "langfuse.observation.metadata.user_id" => "user_42",
         "langfuse.observation.metadata.session_id" => "acct_1_conv_2",
         "langfuse.observation.metadata.trace_tags" => ["captain_v2"].to_json,
         "langfuse.observation.metadata.assistant_id" => "123"
       )
       expect(child_attrs).not_to include("langfuse.trace.input")
+      expect(child_attrs).not_to include("langfuse.observation.input")
+      expect(child_attrs).not_to include("langfuse.observation.type")
     end
 
     it "does NOT set gen_ai.request.model on the root span" do
@@ -575,6 +582,8 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
           "langfuse.session.id" => "acct_1_conv_2",
           "langfuse.trace.tags" => '["captain_v2"]',
           "langfuse.trace.metadata.assistant_id" => "123",
+          "langfuse.release" => "2026.06.29",
+          "langfuse.version" => "sha-abc123",
           "langfuse.observation.metadata.user_id" => "user_42",
           "langfuse.observation.metadata.session_id" => "acct_1_conv_2",
           "langfuse.observation.metadata.trace_tags" => '["captain_v2"]',

--- a/spec/agents/instrumentation/tracing_callbacks_spec.rb
+++ b/spec/agents/instrumentation/tracing_callbacks_spec.rb
@@ -68,6 +68,67 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
     allow(agent_span).to receive_messages(set_attribute: nil, finish: nil)
   end
 
+  def build_context(context = {})
+    instance_double(Agents::RunContext, context: context, callback_manager: instance_double(Agents::CallbackManager))
+  end
+
+  def langfuse_metadata_provider
+    lambda do |_ctx|
+      {
+        "langfuse.user.id" => "user_42",
+        "langfuse.trace.metadata.assistant_id" => "123"
+      }
+    end
+  end
+
+  def callbacks_with_langfuse_metadata(trace_tags: '["captain_v2"]')
+    described_class.new(
+      tracer: tracer,
+      span_attributes: { "langfuse.trace.tags" => trace_tags },
+      attribute_provider: langfuse_metadata_provider
+    )
+  end
+
+  def start_langfuse_metadata_run(callbacks, context)
+    allow(tracer).to receive(:start_span).and_return(root_span, agent_span)
+    callbacks.on_run_start("TestAgent", "Hello", context)
+    callbacks.on_agent_thinking("TestAgent", "What is your refund policy?", context)
+    allow(tracer).to receive(:start_span).and_return(llm_span)
+  end
+
+  def configure_tool_flow_chat(chat, system_message, user_message, assistant_message)
+    tool_call_msg = instance_double(
+      RubyLLM::Message,
+      role: :assistant,
+      content: nil,
+      input_tokens: 100,
+      output_tokens: 20,
+      tool_call?: true,
+      tool_calls: {
+        "c1" => instance_double(RubyLLM::ToolCall, name: "faq_lookup", arguments: { query: "refund" })
+      }
+    )
+    tool_result_msg = instance_double(RubyLLM::Message, role: :tool, content: "Refund policy: 30 days")
+    messages_call = 0
+
+    allow(chat).to receive(:messages) do
+      messages_call += 1
+      next [system_message, user_message, tool_call_msg] if messages_call == 1
+
+      [system_message, user_message, tool_call_msg, tool_result_msg, assistant_message]
+    end
+    allow(chat).to receive(:on_end_message).and_yield(tool_call_msg).and_yield(assistant_message)
+  end
+
+  def capture_generation_span_attributes
+    generation_attrs = []
+    allow(tracer).to receive(:start_span) do |name, **opts|
+      generation_attrs << opts[:attributes] if name == "agents.run.generation"
+      llm_span
+    end
+    generation_attrs
+  end
+
   describe "#on_run_start" do
     it "opens a root span with agents.run name" do
       allow(tracer).to receive(:start_span).and_return(root_span)
@@ -91,10 +152,32 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
 
       tracing = context_wrapper.context[:__otel_tracing]
       expect(tracing[:root_span]).to eq(root_span)
+      expect(tracing[:child_langfuse_attributes]).to eq({})
       expect(tracing[:current_tool_span]).to be_nil
       expect(tracing[:current_agent_name]).to be_nil
       expect(tracing[:current_agent_span]).to be_nil
       expect(tracing[:current_agent_context]).to be_nil
+    end
+
+    it "prepares Langfuse trace metadata for child observation spans" do
+      cb = callbacks_with_langfuse_metadata(trace_tags: ["captain_v2"])
+      ctx = build_context(session_id: "acct_1_conv_2")
+      allow(tracer).to receive(:start_span).and_return(root_span)
+
+      cb.on_run_start("TestAgent", "Hello", ctx)
+
+      child_attrs = ctx.context[:__otel_tracing][:child_langfuse_attributes]
+      expect(child_attrs).to include(
+        "langfuse.user.id" => "user_42",
+        "langfuse.session.id" => "acct_1_conv_2",
+        "langfuse.trace.tags" => ["captain_v2"],
+        "langfuse.trace.metadata.assistant_id" => "123",
+        "langfuse.observation.metadata.user_id" => "user_42",
+        "langfuse.observation.metadata.session_id" => "acct_1_conv_2",
+        "langfuse.observation.metadata.trace_tags" => ["captain_v2"].to_json,
+        "langfuse.observation.metadata.assistant_id" => "123"
+      )
+      expect(child_attrs).not_to include("langfuse.trace.input")
     end
 
     it "does NOT set gen_ai.request.model on the root span" do
@@ -477,34 +560,58 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
       expect(llm_span).to have_received(:finish)
     end
 
-    it "includes tool results in input when tools ran between LLM calls" do
-      tool_call_msg = instance_double(RubyLLM::Message, role: :assistant, content: nil,
-                                                        input_tokens: 100, output_tokens: 20,
-                                                        tool_call?: true,
-                                                        tool_calls: { "c1" => instance_double(RubyLLM::ToolCall,
-                                                                                              name: "faq_lookup",
-                                                                                              arguments: { query: "refund" }) })
-      tool_result_msg = instance_double(RubyLLM::Message, role: :tool, content: "Refund policy: 30 days")
+    it "propagates root Langfuse metadata to LLM generation spans" do
+      cb = callbacks_with_langfuse_metadata
+      fresh_context = build_context(session_id: "acct_1_conv_2")
+      start_langfuse_metadata_run(cb, fresh_context)
 
-      # Track which messages the chat has at each point
-      messages_call = 0
-      allow(chat).to receive(:messages) do
-        messages_call += 1
-        if messages_call == 1
-          [system_message, user_message, tool_call_msg]
-        else
-          [system_message, user_message, tool_call_msg, tool_result_msg, assistant_message]
+      cb.on_chat_created(chat, "TestAgent", "gpt-4o", fresh_context)
+
+      expect(tracer).to have_received(:start_span).with(
+        "agents.run.generation",
+        with_parent: anything,
+        attributes: hash_including(
+          "langfuse.user.id" => "user_42",
+          "langfuse.session.id" => "acct_1_conv_2",
+          "langfuse.trace.tags" => '["captain_v2"]',
+          "langfuse.trace.metadata.assistant_id" => "123",
+          "langfuse.observation.metadata.user_id" => "user_42",
+          "langfuse.observation.metadata.session_id" => "acct_1_conv_2",
+          "langfuse.observation.metadata.trace_tags" => '["captain_v2"]',
+          "langfuse.observation.metadata.assistant_id" => "123"
+        )
+      )
+    end
+
+    it "adds caller-provided generation attributes" do
+      provider = Class.new do
+        def call(_ctx)
+          {}
+        end
+
+        def generation_attributes(_ctx, _chat, message)
+          { "app.generation.has_tool_calls" => message.tool_calls&.any? }
         end
       end
+      cb = described_class.new(tracer: tracer, attribute_provider: provider.new)
+      fresh_context = build_context
+      allow(tracer).to receive(:start_span).and_return(root_span, agent_span)
+      cb.on_run_start("TestAgent", "Hello", fresh_context)
+      cb.on_agent_thinking("TestAgent", "What is your refund policy?", fresh_context)
+      allow(tracer).to receive(:start_span).and_return(llm_span)
 
-      allow(chat).to receive(:on_end_message).and_yield(tool_call_msg).and_yield(assistant_message)
+      cb.on_chat_created(chat, "TestAgent", "gpt-4o", fresh_context)
 
-      # Capture the attributes from each start_span call
-      span_inputs = []
-      allow(tracer).to receive(:start_span) do |name, **opts|
-        span_inputs << opts.dig(:attributes, "langfuse.observation.input") if name == "agents.run.generation"
-        llm_span
-      end
+      expect(tracer).to have_received(:start_span).with(
+        "agents.run.generation",
+        with_parent: anything,
+        attributes: hash_including("app.generation.has_tool_calls" => false)
+      )
+    end
+
+    it "includes tool results in input when tools ran between LLM calls" do
+      configure_tool_flow_chat(chat, system_message, user_message, assistant_message)
+      generation_attrs = capture_generation_span_attributes
 
       callbacks.on_chat_created(chat, "TestAgent", "gpt-4o", context_wrapper)
 
@@ -522,7 +629,7 @@ RSpec.describe Agents::Instrumentation::TracingCallbacks do
         { role: "tool", content: "Refund policy: 30 days" }
       ].to_json
 
-      expect(span_inputs).to eq([first_input, second_input])
+      expect(generation_attrs.map { |attrs| attrs["langfuse.observation.input"] }).to eq([first_input, second_input])
     end
 
     it "sets token usage attributes on the LLM span" do

--- a/spec/integration/live_instrumentation_spec.rb
+++ b/spec/integration/live_instrumentation_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe "Live instrumentation smoke test", :live_llm do
 
       gen_attrs = gen_spans.last.attributes
       expect(gen_attrs["gen_ai.request.model"]).not_to be_nil
+      expect(gen_attrs["gen_ai.request.temperature"]).to eq(0)
       expect(gen_attrs["gen_ai.usage.input_tokens"]).to be > 0
       expect(gen_attrs["gen_ai.usage.output_tokens"]).to be > 0
       expect(gen_attrs["langfuse.observation.output"]).not_to be_nil


### PR DESCRIPTION
Current instrumentation happens at Trace level. But actual unit of work is a Generation. To run evals on them, we need to be able to filter them based on trace attributes. That can only happen if we propagate the trace attributes to generations. This PR enables that. 

Before:
<img width="436" height="617" alt="CleanShot 2026-06-29 at 10 38 12" src="https://github.com/user-attachments/assets/865b7984-71f7-4986-969d-5e9c45a0b95f" />

After:
<img width="441" height="558" alt="CleanShot 2026-06-29 at 10 38 41" src="https://github.com/user-attachments/assets/b2b12511-a460-4288-8970-523304ec699b" />

<img width="446" height="577" alt="CleanShot 2026-06-29 at 10 39 04" src="https://github.com/user-attachments/assets/66722e2e-9fca-453b-b12a-9e2b6fc8d811" />
