### PR TITLE
feat: support custom handoff tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Allow individual agent relationships to register custom `HandoffTool` factories and acceptance hooks.
+- Carry optional handoff reasons and metadata into hooks and `agent_handoff` callbacks without persisting them to conversation history.
+
+### Fixed
+- Prevent concurrently executed handoff tools from overwriting the first accepted pending handoff.
+
 ## [0.12.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A delightful provider agnostic Ruby SDK for building multi-agent AI workflows wi
 ## ✨ Features
 
 - **🤖 Multi-Agent Orchestration**: Create specialized AI agents that work together
-- **🔄 Seamless Handoffs**: Transparent agent-to-agent transfers (users never know!)
+- **🔄 Seamless Handoffs**: Transparent transfers with optional custom schemas, metadata, and hooks
 - **🛠️ Tool Integration**: Agents can use custom tools and functions
 - **📊 Structured Output**: JSON schema-validated responses for reliable data extraction
 - **💾 Shared Context**: State management across agent interactions
@@ -154,6 +154,8 @@ triage.register_handoffs(billing, support)
 billing.register_handoffs(triage)
 support.register_handoffs(triage)
 ```
+
+Individual relationships can use a custom `Agents::HandoffTool` through `register_handoff`. This supports typed handoff parameters and an acceptance hook while keeping `register_handoffs` fully backward compatible. See [Custom Handoff Tools](docs/concepts/handoffs.md#custom-handoff-tools).
 
 ### Context Management & Persistence
 

--- a/docs/concepts/handoffs.md
+++ b/docs/concepts/handoffs.md
@@ -29,6 +29,8 @@ Only one handoff can be pending at a time. The first handoff accepted by the run
 
 "First" refers to execution order, not necessarily the order of tool calls in the model response. Applications that require model-order priority should ensure their tool executor preserves that order.
 
+This selection rule does not prevent sequential loops across agent turns. Use distinct agent scopes and an application-level turn or handoff limit when cyclic routing is possible.
+
 ## Why Use Tools for Handoffs?
 
 Using tools for handoffs has several advantages over simply instructing the LLM to hand off the conversation:
@@ -95,6 +97,8 @@ triage.register_handoff(
 The tool factory receives `source_agent:` and `target_agent:` keyword arguments. It must return an `Agents::HandoffTool` configured for the registered target. A custom tool defines its own parameters and calls the protected `prepare_handoff` method with any optional `reason`, `metadata`, and halt `message`.
 
 The acceptance hook receives the current `RunContext` and the complete handoff information before the destination agent is configured. Hook failures fail the run instead of silently continuing with partially applied context.
+
+Configure all handoff relationships before using an agent with a runner. Do not mutate `handoffs`, `handoff_agents`, or replace relationships while a run is in progress; runtime relationship reconfiguration is not supported.
 
 ### Callback Data
 

--- a/docs/concepts/handoffs.md
+++ b/docs/concepts/handoffs.md
@@ -23,9 +23,11 @@ Here's how the handoff process works:
 4.  **The Runner switches agents:** The `Runner` detects the `pending_handoff` flag and switches the `current_agent` to the new agent.
 5.  **The conversation continues:** The conversation continues with the new agent, which now has access to the full conversation history.
 
-### Loop Prevention
+### Concurrent Handoff Selection
 
-To prevent infinite handoff loops, the library automatically processes only the first handoff tool call in any LLM response. If multiple handoff tools are called in a single response, only the first one is executed and subsequent calls are ignored. This prevents conflicting handoff states and ensures clean agent transitions.
+Only one handoff can be pending at a time. The first handoff accepted by the run context wins, and later handoff executions cannot overwrite it. This guarantee is thread-safe even when a tool executor runs calls concurrently.
+
+"First" refers to execution order, not necessarily the order of tool calls in the model response. Applications that require model-order priority should ensure their tool executor preserves that order.
 
 ## Why Use Tools for Handoffs?
 
@@ -58,6 +60,60 @@ result = Agents::Runner.run(triage_agent, "I have a problem with my bill.")
 
 In this example, the `triage_agent` will automatically hand off the conversation to the `billing_agent` when the user asks a question about their bill. This allows you to create a seamless user experience where the user is always talking to the most qualified agent for their needs.
 
+## Custom Handoff Tools
+
+`register_handoffs` remains the simplest option and continues to create parameterless `HandoffTool` instances. Use `register_handoff` when one relationship needs a custom schema, operational metadata, or an acceptance hook.
+
+```ruby
+class DelegationTool < Agents::HandoffTool
+  description "Delegate work with the context needed by the destination agent"
+
+  param :reason, type: "string", desc: "Why this destination is required"
+  param :summary, type: "string", desc: "Relevant operational context"
+
+  def perform(tool_context, reason:, summary:)
+    prepare_handoff(
+      tool_context,
+      reason: reason,
+      metadata: { summary: summary },
+      message: "Delegating to #{target_agent.name}"
+    )
+  end
+end
+
+triage.register_handoff(
+  billing,
+  tool_factory: lambda do |source_agent:, target_agent:|
+    DelegationTool.new(target_agent)
+  end,
+  on_handoff: lambda do |run_context, handoff_info|
+    run_context.context[:delegation] = handoff_info[:metadata]
+  end
+)
+```
+
+The tool factory receives `source_agent:` and `target_agent:` keyword arguments. It must return an `Agents::HandoffTool` configured for the registered target. A custom tool defines its own parameters and calls the protected `prepare_handoff` method with any optional `reason`, `metadata`, and halt `message`.
+
+The acceptance hook receives the current `RunContext` and the complete handoff information before the destination agent is configured. Hook failures fail the run instead of silently continuing with partially applied context.
+
+### Callback Data
+
+The `agent_handoff` callback now receives two optional trailing values:
+
+```ruby
+lambda do |from_agent, to_agent, reason, run_context, metadata|
+  # Observe the accepted handoff.
+end
+```
+
+Existing strict lambdas with the original three or four arguments remain compatible because callback dispatch slices trailing arguments to the callback's accepted arity.
+
+### Lifetime and Trust Boundary
+
+Handoff metadata is temporary execution state. The runner consumes it during the current handoff and does not automatically add it to the conversation history, system prompt, or a future run. Persist only the durable facts your application actually needs.
+
+Metadata may contain model-generated or user-derived content. Treat it as untrusted operational data. A hook that injects metadata into a destination prompt should state explicitly that the data cannot override the destination agent's role, guardrails, tool requirements, or authorization rules.
+
 ## Troubleshooting Handoffs
 
 ### Infinite Handoff Loops
@@ -78,4 +134,4 @@ In this example, the `triage_agent` will automatically hand off the conversation
 
 ### Multiple Handoffs in One Response
 
-The library automatically handles cases where an LLM tries to call multiple handoff tools in a single response. Only the first handoff will be processed, and subsequent calls will be ignored. This is normal behavior and prevents conflicting handoff states.
+The library atomically accepts one pending handoff. Any later handoff tool execution receives a rejection result and cannot replace the accepted destination. With concurrent executors, the first tool execution accepted by the run context wins.

--- a/lib/agents/agent.rb
+++ b/lib/agents/agent.rb
@@ -50,8 +50,8 @@ require_relative "helpers/hash_normalizer"
 #   )
 module Agents
   class Agent
-    attr_reader :name, :instructions, :model, :provider, :assume_model_exists, :tools, :handoff_agents, :temperature,
-                :response_schema, :headers, :params
+    attr_reader :name, :instructions, :model, :provider, :assume_model_exists, :tools, :handoff_agents, :handoffs,
+                :temperature, :response_schema, :headers, :params
 
     # Initialize a new Agent instance
     #
@@ -75,6 +75,7 @@ module Agents
       @assume_model_exists = assume_model_exists
       @tools = tools.dup
       @handoff_agents = []
+      @handoffs = []
       @temperature = temperature
       @response_schema = response_schema
       @headers = Helpers::HashNormalizer.normalize(headers, label: "headers", freeze_result: true)
@@ -98,11 +99,9 @@ module Agents
     #
     # @return [Array<Agents::Tool>] All tools available to the agent
     def all_tools
-      @mutex.synchronize do
-        # Compute handoff tools dynamically
-        handoff_tools = @handoff_agents.map { |agent| HandoffTool.new(agent) }
-        @tools + handoff_tools
-      end
+      relationships = @mutex.synchronize { @handoffs.dup }
+      handoff_tools = relationships.map { |handoff| handoff.build_tool(source_agent: self) }
+      @tools + handoff_tools
     end
 
     # Register agents that this agent can hand off to.
@@ -123,10 +122,47 @@ module Agents
     #   support.register_handoffs(triage)
     def register_handoffs(*agents)
       @mutex.synchronize do
-        @handoff_agents.concat(agents)
-        @handoff_agents.uniq! # Prevent duplicates
+        agents.each do |agent|
+          next if @handoff_agents.include?(agent)
+
+          @handoff_agents << agent
+          @handoffs << Handoff.new(agent)
+        end
       end
       self
+    end
+
+    # Register one handoff relationship with optional extension points.
+    # Registering the same target again replaces its relationship in place.
+    #
+    # @param agent [Agents::Agent] Destination agent
+    # @param tool_factory [Proc, nil] Builds an Agents::HandoffTool for this relationship
+    # @param on_handoff [Proc, nil] Called with RunContext and accepted handoff information
+    # @return [self] Returns self for method chaining
+    def register_handoff(agent, tool_factory: nil, on_handoff: nil)
+      relationship = Handoff.new(agent, tool_factory: tool_factory, on_handoff: on_handoff)
+
+      @mutex.synchronize do
+        index = @handoff_agents.index(agent)
+        if index
+          @handoffs[index] = relationship
+        else
+          @handoff_agents << agent
+          @handoffs << relationship
+        end
+      end
+      self
+    end
+
+    # Return the relationship configured for a target agent.
+    #
+    # @param agent [Agents::Agent] Destination agent
+    # @return [Agents::Handoff, nil] Configured relationship
+    def handoff_for(agent)
+      @mutex.synchronize do
+        index = @handoff_agents.index(agent)
+        index ? @handoffs[index] : nil
+      end
     end
 
     # Creates a new agent instance with modified attributes while preserving immutability.
@@ -168,19 +204,25 @@ module Agents
     # @option changes [Hash, nil] :response_schema JSON schema for structured output
     # @return [Agents::Agent] A new frozen agent instance with the specified changes
     def clone(**changes)
-      self.class.new(
+      handoff_agents_changed = changes.key?(:handoff_agents)
+      cloned = self.class.new(
         name: changes.fetch(:name, @name),
         instructions: changes.fetch(:instructions, @instructions),
         model: changes.fetch(:model, @model),
         provider: changes.fetch(:provider, @provider),
         assume_model_exists: changes.fetch(:assume_model_exists, @assume_model_exists),
         tools: changes.fetch(:tools, @tools.dup),
-        handoff_agents: changes.fetch(:handoff_agents, @handoff_agents),
+        handoff_agents: handoff_agents_changed ? changes[:handoff_agents] : [],
         temperature: changes.fetch(:temperature, @temperature),
         response_schema: changes.fetch(:response_schema, @response_schema),
         headers: changes.fetch(:headers, @headers),
         params: changes.fetch(:params, @params)
       )
+
+      return cloned if handoff_agents_changed
+
+      copy_handoffs_to(cloned)
+      cloned
     end
 
     # Get the system prompt for the agent, potentially customized based on runtime context.
@@ -252,6 +294,19 @@ module Agents
         description: description,
         output_extractor: output_extractor
       )
+    end
+
+    private
+
+    def copy_handoffs_to(cloned)
+      relationships = @mutex.synchronize { @handoffs.dup }
+      relationships.each do |handoff|
+        cloned.register_handoff(
+          handoff.target_agent,
+          tool_factory: handoff.tool_factory,
+          on_handoff: handoff.on_handoff
+        )
+      end
     end
   end
 end

--- a/lib/agents/agent_runner.rb
+++ b/lib/agents/agent_runner.rb
@@ -125,7 +125,9 @@ module Agents
     # Register a callback for agent handoff events.
     # Called when control is transferred from one agent to another.
     #
-    # @param block [Proc] Callback block that receives (from_agent, to_agent, reason)
+    # @param block [Proc] Callback block that receives
+    #   (from_agent, to_agent, reason, context_wrapper, metadata)
+    #   Trailing arguments remain compatible with callbacks that accept fewer values.
     # @return [self] For method chaining
     def on_agent_handoff(&block)
       return self unless block

--- a/lib/agents/handoff.rb
+++ b/lib/agents/handoff.rb
@@ -1,6 +1,55 @@
 # frozen_string_literal: true
 
 module Agents
+  # Defines a handoff relationship between two agents.
+  #
+  # A relationship may customize the tool presented to the model and run a hook
+  # after the handoff is accepted. The default behavior remains HandoffTool with
+  # no parameters, preserving compatibility with register_handoffs.
+  class Handoff
+    attr_reader :target_agent, :tool_factory, :on_handoff
+
+    def initialize(target_agent, tool_factory: nil, on_handoff: nil)
+      validate_callable(:tool_factory, tool_factory)
+      validate_callable(:on_handoff, on_handoff)
+
+      @target_agent = target_agent
+      @tool_factory = tool_factory
+      @on_handoff = on_handoff
+      freeze
+    end
+
+    def build_tool(source_agent:)
+      tool = if @tool_factory
+               @tool_factory.call(source_agent: source_agent, target_agent: @target_agent)
+             else
+               HandoffTool.new(@target_agent)
+             end
+
+      validate_tool(tool)
+      tool
+    end
+
+    def call_hook(context_wrapper, handoff_info)
+      @on_handoff&.call(context_wrapper, handoff_info)
+    end
+
+    private
+
+    def validate_callable(name, callable)
+      return if callable.nil? || callable.respond_to?(:call)
+
+      raise ArgumentError, "#{name} must respond to #call"
+    end
+
+    def validate_tool(tool)
+      raise ArgumentError, "tool_factory must return an Agents::HandoffTool" unless tool.is_a?(HandoffTool)
+      return if tool.target_agent.equal?(@target_agent)
+
+      raise ArgumentError, "custom handoff tool must use the registered target agent"
+    end
+  end
+
   # A special tool that enables agents to transfer conversations to other specialized agents.
   # Handoffs are implemented as tools (following OpenAI's pattern) because this allows
   # the LLM to naturally decide when to transfer based on the conversation context.
@@ -49,12 +98,12 @@ module Agents
   class HandoffTool < Tool
     attr_reader :target_agent
 
-    def initialize(target_agent)
+    def initialize(target_agent, name: nil, description: nil)
       @target_agent = target_agent
 
       # Set up the tool with a standardized name and description
-      @tool_name = "handoff_to_#{Helpers::NameNormalizer.to_tool_name(target_agent.name)}"
-      @tool_description = "Transfer conversation to #{target_agent.name}"
+      @tool_name = name || "handoff_to_#{Helpers::NameNormalizer.to_tool_name(target_agent.name)}"
+      @tool_description = description || self.class.description || "Transfer conversation to #{target_agent.name}"
 
       super()
     end
@@ -72,19 +121,29 @@ module Agents
     # Use RubyLLM's halt mechanism to stop continuation after handoff
     # Store handoff info in context for Runner to detect and process
     def perform(tool_context)
-      # Store handoff information in context for Runner to detect
-      # TODO: The following is a race condition that needs to be addressed in future versions
-      # If multiple handoff tools execute concurrently, they overwrite each other's pending_handoff data.
-      tool_context.run_context.context[:pending_handoff] = {
-        target_agent: @target_agent,
-        timestamp: Time.now
-      }
-
-      # Return halt to stop LLM continuation
-      halt("I'll transfer you to #{@target_agent.name} who can better assist you with this.")
+      prepare_handoff(tool_context)
     end
 
     # NOTE: RubyLLM will handle schema generation internally when needed
     # Handoff tools have no parameters, which RubyLLM will detect automatically
+
+    protected
+
+    # Accept a handoff with optional operational data.
+    # Subclasses can expose their own parameter schema and pass the resulting
+    # values here without changing Runner internals.
+    def prepare_handoff(tool_context, reason: nil, metadata: nil, message: nil)
+      handoff_info = {
+        target_agent: @target_agent,
+        timestamp: Time.now
+      }
+      handoff_info[:reason] = reason unless reason.nil?
+      handoff_info[:metadata] = metadata unless metadata.nil?
+
+      accepted = tool_context.run_context.prepare_handoff(handoff_info)
+      return "A handoff is already pending; no additional handoff was created." unless accepted
+
+      halt(message || "I'll transfer you to #{@target_agent.name} who can better assist you with this.")
+    end
   end
 end

--- a/lib/agents/handoff.rb
+++ b/lib/agents/handoff.rb
@@ -61,10 +61,10 @@ module Agents
   # 4. The tool signals the handoff through context
   # 5. The Runner detects this and switches to the new agent
   #
-  # ## Loop Prevention
-  # The library prevents infinite handoff loops by processing only the first handoff
-  # tool call in any LLM response. This is handled automatically by the Chat class
-  # which detects handoff tools and processes them separately from regular tools.
+  # ## Concurrent Handoff Selection
+  # Only one handoff may be pending at a time. The first handoff accepted by
+  # RunContext wins. This does not prevent sequential handoff loops across
+  # multiple agent turns.
   #
   # ## Why Tools Instead of Instructions
   # Using tools for handoffs has several advantages:
@@ -92,9 +92,9 @@ module Agents
   #
   # @example Multiple handoff handling
   #   # Single LLM response with multiple handoff calls:
-  #   # Call 1: handoff_to_support() -> Processed and executed
-  #   # Call 2: handoff_to_billing() -> Ignored (only first handoff processed)
-  #   # Result: Only transfers to Support Agent
+  #   # First handoff accepted by RunContext -> Processed and executed
+  #   # Later handoff executions -> Rejected while one is pending
+  #   # With concurrent execution, model emission order does not determine the winner
   class HandoffTool < Tool
     attr_reader :target_agent
 

--- a/lib/agents/instrumentation.rb
+++ b/lib/agents/instrumentation.rb
@@ -99,7 +99,7 @@ module Agents
     # Register all tracing callback handlers on the runner.
     def self.register_callbacks(runner, callbacks)
       TRACED_EVENTS.each do |event|
-        runner.public_send(:"on_#{event}") { |*args| callbacks.public_send(:"on_#{event}", *args) }
+        runner.public_send(:"on_#{event}", &callbacks.method(:"on_#{event}"))
       end
     end
     private_class_method :register_callbacks

--- a/lib/agents/run_context.rb
+++ b/lib/agents/run_context.rb
@@ -67,6 +67,33 @@ module Agents
       @usage = Usage.new
       @callbacks = callbacks || {}
       @callback_manager = CallbackManager.new(@callbacks)
+      @handoff_mutex = Mutex.new
+    end
+
+    # Store the first handoff accepted during the current execution step.
+    # Concurrent calls are serialized so later handoffs cannot overwrite it.
+    #
+    # @param handoff_info [Hash] Target and optional handoff data
+    # @return [Boolean] true when accepted, false when another handoff is pending
+    def prepare_handoff(handoff_info)
+      @handoff_mutex.synchronize do
+        return false if @context[:pending_handoff]
+
+        @context[:pending_handoff] = handoff_info
+        true
+      end
+    end
+
+    # Atomically remove and return the pending handoff.
+    #
+    # @return [Hash, nil] The pending handoff information
+    def take_pending_handoff
+      @handoff_mutex.synchronize { @context.delete(:pending_handoff) }
+    end
+
+    # Clear temporary handoff state after a run is finalized.
+    def clear_pending_handoff
+      @handoff_mutex.synchronize { @context.delete(:pending_handoff) }
     end
 
     # Usage tracks token consumption across all LLM calls within a single run.

--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -147,7 +147,7 @@ module Agents
 
         # Check for handoff via RubyLLM's halt mechanism
         if response.is_a?(RubyLLM::Tool::Halt) && context_wrapper.context[:pending_handoff]
-          handoff_info = context_wrapper.context.delete(:pending_handoff)
+          handoff_info = context_wrapper.take_pending_handoff
           next_agent = handoff_info[:target_agent]
 
           # Validate that the target agent is in our registry
@@ -157,6 +157,8 @@ module Agents
             return finalize_run(chat, context_wrapper, current_agent, output: nil, error: error)
           end
 
+          handoff_relationship(current_agent, next_agent)&.call_hook(context_wrapper, handoff_info)
+
           # Save current conversation state before switching
           save_conversation_state(chat, context_wrapper, current_agent)
 
@@ -164,8 +166,13 @@ module Agents
           context_wrapper.callback_manager.emit_agent_complete(current_agent.name, nil, nil, context_wrapper)
 
           # Emit agent handoff event
-          context_wrapper.callback_manager.emit_agent_handoff(current_agent.name, next_agent.name, "handoff",
-                                                              context_wrapper)
+          context_wrapper.callback_manager.emit_agent_handoff(
+            current_agent.name,
+            next_agent.name,
+            handoff_info[:reason] || "handoff",
+            context_wrapper,
+            handoff_info[:metadata]
+          )
 
           # Switch to new agent - store agent name for persistence
           current_agent = next_agent
@@ -383,7 +390,7 @@ module Agents
       context_wrapper.context[:last_updated] = Time.now
 
       # Clean up temporary handoff state
-      context_wrapper.context.delete(:pending_handoff)
+      context_wrapper.clear_pending_handoff
     end
 
     def assign_agent_name_to_new_assistant_messages(chat, current_agent, start_index)
@@ -485,13 +492,12 @@ module Agents
     # @param context_wrapper [RunContext] Thread-safe context wrapper for tool execution
     # @return [Array<ToolWrapper>] Array of wrapped tools ready for RubyLLM
     def build_agent_tools(agent, context_wrapper)
-      all_tools = []
-
-      # Add handoff tools
-      agent.handoff_agents.each do |target_agent|
-        handoff_tool = HandoffTool.new(target_agent)
-        all_tools << ToolWrapper.new(handoff_tool, context_wrapper)
-      end
+      handoff_tools = if agent.is_a?(Agent)
+                        agent.handoffs.map { |handoff| handoff.build_tool(source_agent: agent) }
+                      else
+                        agent.handoff_agents.map { |target_agent| HandoffTool.new(target_agent) }
+                      end
+      all_tools = handoff_tools.map { |tool| ToolWrapper.new(tool, context_wrapper) }
 
       # Add regular tools
       agent.tools.each do |tool|
@@ -499,6 +505,12 @@ module Agents
       end
 
       all_tools
+    end
+
+    def handoff_relationship(agent, target_agent)
+      return unless agent.is_a?(Agent)
+
+      agent.handoff_for(target_agent)
     end
   end
 end

--- a/spec/agents/agent_spec.rb
+++ b/spec/agents/agent_spec.rb
@@ -169,6 +169,47 @@ RSpec.describe Agents::Agent do
     end
   end
 
+  describe "#register_handoff" do
+    let(:agent) { described_class.new(name: "Test Agent") }
+    let(:handoff_agent) { instance_double(described_class, name: "Handoff Agent") }
+
+    it "registers a custom handoff relationship" do
+      factory = lambda do |target_agent:, source_agent:|
+        expect(target_agent).to be(handoff_agent)
+        expect(source_agent).to be(agent)
+        Agents::HandoffTool.new(target_agent)
+      end
+      hook = ->(_context, _handoff_info) {}
+
+      result = agent.register_handoff(handoff_agent, tool_factory: factory, on_handoff: hook)
+
+      expect(result).to be(agent)
+      expect(agent.handoff_agents).to eq([handoff_agent])
+      expect(agent.handoff_for(handoff_agent)).to have_attributes(tool_factory: factory, on_handoff: hook)
+      expect(agent.all_tools.last).to be_a(Agents::HandoffTool)
+    end
+
+    it "replaces the relationship without duplicating the target" do
+      original_factory = ->(target_agent:, **) { Agents::HandoffTool.new(target_agent) }
+      replacement_factory = ->(target_agent:, **) { Agents::HandoffTool.new(target_agent) }
+
+      agent.register_handoff(handoff_agent, tool_factory: original_factory)
+      agent.register_handoff(handoff_agent, tool_factory: replacement_factory)
+
+      expect(agent.handoff_agents).to eq([handoff_agent])
+      expect(agent.handoff_for(handoff_agent).tool_factory).to be(replacement_factory)
+    end
+
+    it "does not overwrite a custom relationship through bulk registration" do
+      factory = ->(target_agent:, **) { Agents::HandoffTool.new(target_agent) }
+
+      agent.register_handoff(handoff_agent, tool_factory: factory)
+      agent.register_handoffs(handoff_agent)
+
+      expect(agent.handoff_for(handoff_agent).tool_factory).to be(factory)
+    end
+  end
+
   describe "#all_tools" do
     let(:agent) { described_class.new(name: "Test Agent", tools: [test_tool]) }
     let(:handoff_agent) { instance_double(described_class, name: "Handoff Agent") }
@@ -228,6 +269,27 @@ RSpec.describe Agents::Agent do
       expect(cloned.handoff_agents).to eq([other_agent])
       expect(cloned.headers).to eq("X-Test": "value")
       expect(cloned.headers).to be_frozen
+    end
+
+    it "preserves custom handoff relationships when cloning" do
+      factory = ->(target_agent:, **) { Agents::HandoffTool.new(target_agent) }
+      hook = ->(_context, _handoff_info) {}
+      original_agent.register_handoff(other_agent, tool_factory: factory, on_handoff: hook)
+
+      cloned = original_agent.clone
+
+      expect(cloned.handoff_for(other_agent)).to have_attributes(tool_factory: factory, on_handoff: hook)
+    end
+
+    it "uses default relationships when handoff agents are explicitly overridden" do
+      replacement = instance_double(described_class, name: "Replacement")
+      factory = ->(target_agent:, **) { Agents::HandoffTool.new(target_agent) }
+      original_agent.register_handoff(other_agent, tool_factory: factory)
+
+      cloned = original_agent.clone(handoff_agents: [replacement])
+
+      expect(cloned.handoff_agents).to eq([replacement])
+      expect(cloned.handoff_for(replacement).tool_factory).to be_nil
     end
 
     it "overrides specific attributes" do

--- a/spec/agents/custom_handoff_runner_spec.rb
+++ b/spec/agents/custom_handoff_runner_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "webmock/rspec"
+require_relative "../../lib/agents"
+
+RSpec.describe Agents::Runner do
+  include OpenAITestHelper
+
+  let(:custom_tool_class) do
+    Class.new(Agents::HandoffTool) do
+      description "Delegate with structured operational context"
+      param :reason, type: "string", desc: "Why this handoff is needed"
+      param :summary, type: "string", desc: "Context for the destination agent"
+
+      def perform(tool_context, reason:, summary:)
+        prepare_handoff(tool_context, reason: reason, metadata: { summary: summary })
+      end
+    end
+  end
+  let(:target) do
+    Agents::Agent.new(name: "Specialist", instructions: "Handle specialist requests", model: "gpt-4o")
+  end
+  let(:hook_calls) { [] }
+  let(:callback_calls) { [] }
+  let(:source) do
+    Agents::Agent.new(name: "Triage", instructions: "Route requests", model: "gpt-4o").tap do |agent|
+      agent.register_handoff(
+        target,
+        tool_factory: ->(target_agent:, **) { custom_tool_class.new(target_agent) },
+        on_handoff: lambda do |context, handoff_info|
+          hook_calls << [context, handoff_info]
+          context.context[:received_handoff_metadata] = handoff_info[:metadata]
+        end
+      )
+    end
+  end
+  let(:callbacks) do
+    {
+      agent_handoff: [lambda do |from, to, reason, context, metadata|
+        callback_calls << [from, to, reason, context, metadata]
+      end]
+    }
+  end
+
+  before do
+    setup_openai_test_config
+    disable_net_connect!
+    stub_chat_sequence(
+      {
+        tool_calls: [{
+          name: "handoff_to_specialist",
+          arguments: { reason: "Needs specialist", summary: "Customer selected product 123" }
+        }]
+      },
+      "Specialist response"
+    )
+  end
+
+  after do
+    allow_net_connect!
+  end
+
+  it "uses a custom handoff tool and exposes its reason and metadata to hooks and callbacks" do
+    result = described_class.new.run(
+      source,
+      "Please help",
+      registry: { "Triage" => source, "Specialist" => target },
+      callbacks: callbacks
+    )
+
+    expect(result).to be_success
+    expect(result.output).to eq("Specialist response")
+    expect(result.context[:received_handoff_metadata]).to eq(summary: "Customer selected product 123")
+    expect(hook_calls.one?).to be true
+    expect(hook_calls.first.last).to include(
+      target_agent: target,
+      reason: "Needs specialist",
+      metadata: { summary: "Customer selected product 123" }
+    )
+    expect(callback_calls).to contain_exactly(
+      ["Triage", "Specialist", "Needs specialist", hook_calls.first.first,
+       { summary: "Customer selected product 123" }]
+    )
+  end
+end

--- a/spec/agents/custom_handoff_runner_spec.rb
+++ b/spec/agents/custom_handoff_runner_spec.rb
@@ -41,6 +41,38 @@ RSpec.describe Agents::Runner do
       end]
     }
   end
+  let(:dynamic_prompt_contexts) { [] }
+  let(:dynamic_target) do
+    Agents::Agent.new(
+      name: "DynamicSpecialist",
+      instructions: lambda do |context|
+        dynamic_prompt_contexts << context.context[:received_handoff_metadata]
+        "Handle specialist requests"
+      end,
+      model: "gpt-4o"
+    )
+  end
+  let(:dynamic_source) do
+    Agents::Agent.new(name: "Triage", instructions: "Route requests", model: "gpt-4o").tap do |agent|
+      agent.register_handoff(
+        dynamic_target,
+        tool_factory: ->(target_agent:, **) { custom_tool_class.new(target_agent) },
+        on_handoff: lambda do |context, handoff_info|
+          context.context[:received_handoff_metadata] = handoff_info[:metadata]
+        end
+      )
+    end
+  end
+  let(:failing_source) do
+    Agents::Agent.new(name: "Triage", instructions: "Route requests", model: "gpt-4o").tap do |agent|
+      agent.register_handoff(
+        target,
+        tool_factory: ->(target_agent:, **) { custom_tool_class.new(target_agent) },
+        on_handoff: ->(*) { raise "handoff hook failed" }
+      )
+    end
+  end
+  let(:completed_agents) { [] }
 
   before do
     setup_openai_test_config
@@ -80,6 +112,71 @@ RSpec.describe Agents::Runner do
     expect(callback_calls).to contain_exactly(
       ["Triage", "Specialist", "Needs specialist", hook_calls.first.first,
        { summary: "Customer selected product 123" }]
+    )
+  end
+
+  it "makes hook context available to the destination dynamic prompt" do
+    stub_chat_sequence(
+      {
+        tool_calls: [{
+          name: dynamic_source.all_tools.last.name,
+          arguments: { reason: "Needs specialist", summary: "Customer selected product 123" }
+        }]
+      },
+      "Specialist response"
+    )
+
+    result = described_class.new.run(
+      dynamic_source,
+      "Please help",
+      registry: { "Triage" => dynamic_source, "DynamicSpecialist" => dynamic_target }
+    )
+
+    expect(result).to be_success
+    expect(dynamic_prompt_contexts).to contain_exactly(summary: "Customer selected product 123")
+  end
+
+  it "fails without switching agents when the acceptance hook raises" do
+    result = described_class.new.run(
+      failing_source,
+      "Please help",
+      registry: { "Triage" => failing_source, "Specialist" => target },
+      callbacks: {
+        agent_complete: [lambda do |agent_name, _result, _error, _context|
+          completed_agents << agent_name
+        end]
+      }
+    )
+
+    expect(result).to be_failed
+    expect(result.error).to be_a(RuntimeError)
+    expect(result.error.message).to eq("handoff hook failed")
+    expect(result.context).not_to have_key(:pending_handoff)
+    expect(completed_agents).to eq(["Triage"])
+  end
+
+  it "keeps legacy handoff callback arities compatible in the real runner flow" do
+    three_argument_calls = []
+    four_argument_calls = []
+
+    result = described_class.new.run(
+      source,
+      "Please help",
+      registry: { "Triage" => source, "Specialist" => target },
+      callbacks: {
+        agent_handoff: [
+          ->(from, to, reason) { three_argument_calls << [from, to, reason] },
+          lambda do |from, to, reason, context|
+            four_argument_calls << [from, to, reason, context]
+          end
+        ]
+      }
+    )
+
+    expect(result).to be_success
+    expect(three_argument_calls).to eq([["Triage", "Specialist", "Needs specialist"]])
+    expect(four_argument_calls).to contain_exactly(
+      ["Triage", "Specialist", "Needs specialist", kind_of(Agents::RunContext)]
     )
   end
 end

--- a/spec/agents/handoff_relationship_spec.rb
+++ b/spec/agents/handoff_relationship_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/agents"
+
+RSpec.describe Agents::Handoff do
+  let(:source_agent) { instance_double(Agents::Agent, name: "Triage") }
+  let(:target_agent) { instance_double(Agents::Agent, name: "Billing") }
+
+  describe "#build_tool" do
+    it "builds the default handoff tool when no factory is configured" do
+      relationship = described_class.new(target_agent)
+
+      tool = relationship.build_tool(source_agent: source_agent)
+
+      expect(tool).to be_a(Agents::HandoffTool)
+      expect(tool.target_agent).to be(target_agent)
+    end
+
+    it "builds a custom handoff tool with source and target agents" do
+      custom_tool_class = Class.new(Agents::HandoffTool)
+      received_source = nil
+      factory = lambda do |source_agent:, target_agent:|
+        received_source = source_agent
+        custom_tool_class.new(target_agent)
+      end
+      relationship = described_class.new(target_agent, tool_factory: factory)
+
+      tool = relationship.build_tool(source_agent: source_agent)
+
+      expect(tool).to be_a(custom_tool_class)
+      expect(tool.target_agent).to be(target_agent)
+      expect(received_source).to be(source_agent)
+    end
+
+    it "rejects tools that do not implement the handoff contract" do
+      factory = ->(**) { Agents::Tool.new }
+      relationship = described_class.new(target_agent, tool_factory: factory)
+
+      expect { relationship.build_tool(source_agent: source_agent) }
+        .to raise_error(ArgumentError, /Agents::HandoffTool/)
+    end
+
+    it "rejects tools configured for a different target" do
+      other_agent = instance_double(Agents::Agent, name: "Support")
+      factory = ->(**) { Agents::HandoffTool.new(other_agent) }
+      relationship = described_class.new(target_agent, tool_factory: factory)
+
+      expect { relationship.build_tool(source_agent: source_agent) }
+        .to raise_error(ArgumentError, /registered target agent/)
+    end
+  end
+
+  describe "#call_hook" do
+    it "passes the run context and handoff information to the hook" do
+      calls = []
+      hook = ->(context, handoff_info) { calls << [context, handoff_info] }
+      relationship = described_class.new(target_agent, on_handoff: hook)
+      run_context = Agents::RunContext.new({})
+      handoff_info = { target_agent: target_agent, metadata: { account_id: 123 } }
+
+      relationship.call_hook(run_context, handoff_info)
+
+      expect(calls).to eq([[run_context, handoff_info]])
+    end
+
+    it "does nothing when no hook is configured" do
+      relationship = described_class.new(target_agent)
+
+      expect { relationship.call_hook(Agents::RunContext.new({}), {}) }.not_to raise_error
+    end
+  end
+
+  describe "validation" do
+    it "rejects a non-callable tool factory" do
+      expect { described_class.new(target_agent, tool_factory: "invalid") }
+        .to raise_error(ArgumentError, /tool_factory/)
+    end
+
+    it "rejects a non-callable handoff hook" do
+      expect { described_class.new(target_agent, on_handoff: "invalid") }
+        .to raise_error(ArgumentError, /on_handoff/)
+    end
+  end
+end

--- a/spec/agents/handoff_spec.rb
+++ b/spec/agents/handoff_spec.rb
@@ -29,22 +29,82 @@ RSpec.describe Agents::HandoffTool do
       expected_description = "Transfer conversation to Support Agent"
       expect(handoff_tool.description).to eq(expected_description)
     end
+
+    it "allows subclasses to configure their description with the tool DSL" do
+      custom_tool_class = Class.new(described_class) do
+        description "Transfer with structured context"
+      end
+
+      expect(custom_tool_class.new(target_agent).description).to eq("Transfer with structured context")
+    end
+
+    it "accepts explicit name and description overrides" do
+      tool = described_class.new(target_agent, name: "delegate_support", description: "Delegate to support")
+
+      expect(tool.name).to eq("delegate_support")
+      expect(tool.description).to eq("Delegate to support")
+    end
   end
 
   describe "#perform" do
     it "returns halt with transfer message" do
-      tool_context = instance_double(Agents::ToolContext)
-      run_context = instance_double(Agents::RunContext)
-      context_hash = {}
-
-      allow(tool_context).to receive(:run_context).and_return(run_context)
-      allow(run_context).to receive(:context).and_return(context_hash)
+      run_context = Agents::RunContext.new({})
+      tool_context = Agents::ToolContext.new(run_context: run_context)
 
       result = handoff_tool.perform(tool_context)
 
       expect(result).to be_a(RubyLLM::Tool::Halt)
       expect(result.content).to eq("I'll transfer you to Support Agent who can better assist you with this.")
-      expect(context_hash[:pending_handoff]).to include(target_agent: target_agent)
+      expect(run_context.context[:pending_handoff]).to include(target_agent: target_agent)
+    end
+
+    it "allows subclasses to attach a reason, metadata, and custom halt message" do
+      structured_tool_class = Class.new(described_class) do
+        def perform(tool_context)
+          prepare_handoff(
+            tool_context,
+            reason: "Needs billing expertise",
+            metadata: { account_id: 123 },
+            message: "Routing to billing"
+          )
+        end
+      end
+      run_context = Agents::RunContext.new({})
+      tool_context = Agents::ToolContext.new(run_context: run_context)
+
+      result = structured_tool_class.new(target_agent).perform(tool_context)
+
+      expect(result).to be_a(RubyLLM::Tool::Halt)
+      expect(result.content).to eq("Routing to billing")
+      expect(run_context.context[:pending_handoff]).to include(
+        target_agent: target_agent,
+        reason: "Needs billing expertise",
+        metadata: { account_id: 123 }
+      )
+    end
+
+    it "keeps the first accepted handoff when multiple wrappers execute concurrently" do
+      other_agent = instance_double(Agents::Agent, name: "Billing Agent")
+      run_context = Agents::RunContext.new({})
+      wrappers = [handoff_tool, described_class.new(other_agent)].map do |tool|
+        Agents::ToolWrapper.new(tool, run_context)
+      end
+      ready, start, results = 3.times.map { Queue.new }
+      threads = wrappers.map do |wrapper|
+        Thread.new do
+          ready << true
+          start.pop
+          results << wrapper.call({})
+        end
+      end
+      wrappers.size.times { ready.pop }
+      wrappers.size.times { start << true }
+      threads.each(&:join)
+
+      halt_count = wrappers.size.times.count { results.pop.is_a?(RubyLLM::Tool::Halt) }
+
+      expect(halt_count).to eq(1)
+      expect([target_agent, other_agent]).to include(run_context.context[:pending_handoff][:target_agent])
     end
   end
 

--- a/spec/agents/instrumentation_spec.rb
+++ b/spec/agents/instrumentation_spec.rb
@@ -7,6 +7,7 @@ require_relative "../../lib/agents/instrumentation"
 module OpenTelemetry
   module Trace
     class Tracer; end
+    class Span; end
   end
 end
 
@@ -36,6 +37,14 @@ RSpec.describe Agents::Instrumentation do
       let(:tracer) { instance_double(OpenTelemetry::Trace::Tracer) }
       let(:agent) { Agents::Agent.new(name: "Test", instructions: "test") }
       let(:runner) { Agents::Runner.with_agents(agent) }
+      let(:root_span) { instance_double(OpenTelemetry::Trace::Span, add_event: nil) }
+      let(:context_wrapper) do
+        Agents::RunContext.new({ __otel_tracing: { root_span: root_span } })
+      end
+      let(:handoff_callback_manager) do
+        callback = runner.instance_variable_get(:@callbacks).fetch(:agent_handoff).first
+        Agents::CallbackManager.new(agent_handoff: [callback])
+      end
 
       before do
         allow(described_class).to receive(:otel_available?).and_return(true)
@@ -64,6 +73,29 @@ RSpec.describe Agents::Instrumentation do
         traced_events.each do |event|
           expect(runner).to respond_to(:"on_#{event}")
         end
+      end
+
+      it "keeps handoff tracing compatible when metadata is emitted" do
+        described_class.install(runner, tracer: tracer)
+
+        expect do
+          handoff_callback_manager.emit_agent_handoff(
+            "Triage",
+            "Billing",
+            "capability_match",
+            context_wrapper,
+            { customer_message: "do not export me" }
+          )
+        end.not_to output(/Callback error/).to_stderr
+
+        expect(root_span).to have_received(:add_event).with(
+          "agents.run.handoff",
+          attributes: {
+            "handoff.from" => "Triage",
+            "handoff.to" => "Billing",
+            "handoff.reason" => "capability_match"
+          }
+        )
       end
     end
   end

--- a/spec/agents/run_context_spec.rb
+++ b/spec/agents/run_context_spec.rb
@@ -45,6 +45,48 @@ RSpec.describe Agents::RunContext do
     end
   end
 
+  describe "handoff state" do
+    it "accepts only one pending handoff across concurrent callers" do
+      ready = Queue.new
+      start = Queue.new
+      results = Queue.new
+      threads = 10.times.map do |id|
+        Thread.new do
+          ready << true
+          start.pop
+          accepted = run_context.prepare_handoff(target_agent: id, timestamp: Time.now)
+          results << [id, accepted]
+        end
+      end
+      threads.size.times { ready.pop }
+      threads.size.times { start << true }
+      threads.each(&:join)
+
+      attempts = threads.size.times.map { results.pop }
+      winner = attempts.find { |(_, accepted)| accepted }
+
+      expect(attempts.count { |(_, accepted)| accepted }).to eq(1)
+      expect(run_context.context[:pending_handoff][:target_agent]).to eq(winner.first)
+    end
+
+    it "atomically consumes the pending handoff" do
+      handoff = { target_agent: "Billing", timestamp: Time.now }
+      run_context.prepare_handoff(handoff)
+
+      expect(run_context.take_pending_handoff).to eq(handoff)
+      expect(run_context.take_pending_handoff).to be_nil
+      expect(run_context.context).not_to have_key(:pending_handoff)
+    end
+
+    it "clears pending handoff state" do
+      run_context.prepare_handoff(target_agent: "Billing", timestamp: Time.now)
+
+      run_context.clear_pending_handoff
+
+      expect(run_context.context).not_to have_key(:pending_handoff)
+    end
+  end
+
   describe "context isolation" do
     let(:base_context) { { shared_key: "shared_value" } }
 


### PR DESCRIPTION
This adds public, relationship-level extension points for handoffs while preserving the current parameterless `HandoffTool` behavior.

## What changed

- Add `Agent#register_handoff` with an optional `tool_factory` and `on_handoff` hook.
- Add a generic `Agents::Handoff` relationship object.
- Let `HandoffTool` subclasses define schemas and attach an optional reason, metadata, and halt message.
- Pass accepted reason and metadata to the handoff hook and as trailing `agent_handoff` callback arguments.
- Make pending handoff selection atomic so concurrent tool execution cannot overwrite the first accepted handoff.
- Preserve custom relationships when cloning agents.
- Preserve OpenTelemetry/Langfuse handoff tracing when metadata is emitted without exporting the metadata payload.
- Document execution-order semantics, temporary metadata lifetime, trust boundaries, and the requirement to configure relationships before a run.

## Compatibility

`register_handoffs(*agents)` and the default parameterless handoff tool remain unchanged. Existing strict callback lambdas keep working because the new callback values are appended and arity-aware dispatch trims trailing arguments. Instrumentation registers bound methods so its four-argument handoff callback remains compatible with the five-argument event.

## Validation

- Full RSpec suite: 423 examples, 0 failures.
- Line coverage: 99.12%.
- Focused RuboCop run for the changed handoff, instrumentation, and spec files: no offenses.
- Concurrent execution is covered through real `ToolWrapper` calls sharing one `RunContext`.
- Real Runner coverage verifies hook failure cleanup, destination dynamic prompt timing, legacy callback arities, and tracing with metadata.