### PR TITLE
fix: preserve prebuilt RubyLLM content in conversation history

### DIFF
--- a/lib/agents/runner.rb
+++ b/lib/agents/runner.rb
@@ -338,9 +338,10 @@ module Agents
       params
     end
 
-    # Build RubyLLM::Content from stored content, handling multimodal arrays with image attachments.
+    # Normalize stored content for RubyLLM, preserving prebuilt content and handling multimodal arrays.
     # Multimodal arrays follow the OpenAI content format: [{type: 'text', text: '...'}, {type: 'image_url', ...}]
     def build_content(content_value)
+      return content_value if content_value.is_a?(RubyLLM::Content)
       return RubyLLM::Content.new(content_value) unless content_value.is_a?(Array)
 
       text_parts = content_value.filter_map { |p| p[:text] || p["text"] if (p[:type] || p["type"]) == "text" }

--- a/spec/agents/runner_spec.rb
+++ b/spec/agents/runner_spec.rb
@@ -450,6 +450,57 @@ RSpec.describe Agents::Runner do
       end
     end
 
+    context "with prebuilt RubyLLM content in history" do
+      it "preserves typed image content during normalization" do
+        content = RubyLLM::Content.new(
+          "Here is the original screenshot",
+          ["https://example.com/original.png"]
+        )
+
+        normalized_content = described_class.new.send(:build_content, content)
+
+        expect(normalized_content).to equal(content)
+        expect(normalized_content.text).to eq("Here is the original screenshot")
+        expect(normalized_content.attachments.first.source.to_s).to eq("https://example.com/original.png")
+      end
+
+      it "preserves typed PDF content during normalization" do
+        content = RubyLLM::Content.new(
+          "Use the attached guide",
+          ["https://example.com/guide.pdf"]
+        )
+
+        normalized_content = described_class.new.send(:build_content, content)
+
+        expect(normalized_content).to equal(content)
+        expect(normalized_content.text).to eq("Use the attached guide")
+        expect(normalized_content.attachments.first.source.to_s).to eq("https://example.com/guide.pdf")
+      end
+
+      it "round trips extracted typed history without nesting its content" do
+        content = RubyLLM::Content.new(
+          "Compare these attachments",
+          ["https://example.com/screenshot.png", "https://example.com/guide.pdf"]
+        )
+        source_message = RubyLLM::Message.new(role: :user, content: content)
+        source_chat = instance_double(RubyLLM::Chat, messages: [source_message])
+        history = Agents::Helpers::MessageExtractor.extract_messages(source_chat, agent)
+        context_wrapper = Agents::RunContext.new({ conversation_history: history })
+        runner_instance = described_class.new
+        restored_chat = instance_double(RubyLLM::Chat)
+        restored_messages = []
+        allow(restored_chat).to receive(:add_message) { |message| restored_messages << message }
+
+        runner_instance.send(:restore_conversation_history, restored_chat, context_wrapper)
+
+        restored_content = restored_messages.first.content
+        expect(restored_content.text).to eq("Compare these attachments")
+        expect(restored_content.attachments.map { |attachment| attachment.source.to_s }).to eq(
+          ["https://example.com/screenshot.png", "https://example.com/guide.pdf"]
+        )
+      end
+    end
+
     context "with tool message history" do
       let(:context_with_tool_history) do
         {


### PR DESCRIPTION
Prebuilt `RubyLLM::Content` values in `conversation_history` were being passed to `RubyLLM::Content.new` again, producing an intermediate content object whose `text` was another content object.

This change treats the native RubyLLM type as already normalized. Existing strings and OpenAI-style multimodal arrays keep their current behavior.

Regression coverage includes typed image content, typed PDF content, and a full `MessageExtractor` → context → Runner round trip.